### PR TITLE
Update camera.cpp for compatibility with cv_bridge in ros2

### DIFF
--- a/src/converters/camera.cpp
+++ b/src/converters/camera.cpp
@@ -26,7 +26,7 @@
 /*
 * ROS includes
 */
-#include <cv_bridge/cv_bridge.hpp>
+#include <cv_bridge/cv_bridge.h>
 
 /*
 * CV includes


### PR DESCRIPTION
The lib won't compile with the latest version of ros2 vision_opencv in humble, source from this fix:

https://github.com/ros-planning/navigation2/issues/3455#issuecomment-1459616739