### PR TITLE
Update to match NAOqi 2.9 fixes in driver_helper and add warning for port to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ for robots running NAOqi 2.9 or greater:
 ros2 launch naoqi_driver naoqi_driver.launch.py nao_ip:=<robot_host> nao_username:=nao nao_password:=<robot_password> qi_listen_url:=tcp://0.0.0.0:0
 ```
 
+Warning: If you have a `connection refused error` such as [this issue](https://github.com/ros-naoqi/naoqi_driver/issues/162)
+(from ROS1 driver version) when using robots running NAOqi 2.8 and greater, please try to give `nao_port:=9503` explicitly.
 
 ### From a Docker container
 

--- a/src/helpers/driver_helpers.cpp
+++ b/src/helpers/driver_helpers.cpp
@@ -16,6 +16,8 @@
 */
 
 #include "driver_helpers.hpp"
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
 
 namespace naoqi
 {
@@ -23,6 +25,10 @@ namespace helpers
 {
 namespace driver
 {
+
+namespace pt = boost::property_tree;
+
+static pt::ptree empty_ptree;
 
 /** Function that returns the type of a robot
  */
@@ -68,112 +74,180 @@ static naoqi_bridge_msgs::msg::RobotInfo& getRobotInfoLocal( const qi::SessionPt
 
   // Get the data from RobotConfig
   qi::AnyObject p_motion = session->service("ALMotion").value();
-  std::vector<std::vector<qi::AnyValue> > config = p_motion.call<std::vector<std::vector<qi::AnyValue> > >("getRobotConfig");
-
-  // TODO, fill with the proper string matches from http://doc.aldebaran.com/2-1/naoqi/motion/tools-general-api.html#ALMotionProxy::getRobotConfig
-
-  for (size_t i=0; i<config[0].size();++i)
-  {
-    if (config[0][i].as<std::string>() == "Model Type")
+    try
     {
-      try{
-        info.model = config[1][i].as<std::string>();
-      }
-      catch(const std::exception& e)
-      {
-        std::cout << "Error in robot config variable " << (config[0][i]).as<std::string>() << std::endl;
-      }
-    }
+        std::vector<std::vector<qi::AnyValue>> config = p_motion.call<std::vector<std::vector<qi::AnyValue>>>("getRobotConfig");
 
-    if (config[0][i].as<std::string>() == "Head Version")
+        // TODO, fill with the proper string matches from http://doc.aldebaran.com/2-1/naoqi/motion/tools-general-api.html#ALMotionProxy::getRobotConfig
+
+        for (size_t i = 0; i < config[0].size(); ++i)
+        {
+            if (config[0][i].as<std::string>() == "Model Type")
+            {
+                try
+                {
+                    info.model = config[1][i].as<std::string>();
+                }
+                catch (const std::exception &e)
+                {
+                    std::cout << "Error in robot config variable " << (config[0][i]).as<std::string>() << std::endl;
+                }
+            }
+
+            if (config[0][i].as<std::string>() == "Head Version")
+            {
+                try
+                {
+                    info.head_version = config[1][i].as<std::string>();
+                }
+                catch (const std::exception &e)
+                {
+                    std::cout << "Error in robot config variable " << (config[0][i]).as<std::string>() << std::endl;
+                }
+            }
+
+            if (config[0][i].as<std::string>() == "Body Version")
+            {
+                try
+                {
+                    info.body_version = config[1][i].as<std::string>();
+                }
+                catch (const std::exception &e)
+                {
+                    std::cout << "Error in robot config variable " << (config[0][i]).as<std::string>() << std::endl;
+                }
+            }
+
+            if (config[0][i].as<std::string>() == "Arm Version")
+            {
+                try
+                {
+                    info.arm_version = config[1][i].as<std::string>();
+                }
+                catch (const std::exception &e)
+                {
+                    std::cout << "Error in robot config variable " << (config[0][i]).as<std::string>() << std::endl;
+                }
+            }
+
+            if (config[0][i].as<std::string>() == "Laser")
+            {
+                try
+                {
+                    info.has_laser = config[1][i].as<bool>();
+                }
+                catch (const std::exception &e)
+                {
+                    std::cout << "Error in robot config variable " << (config[0][i]).as<std::string>() << std::endl;
+                }
+            }
+
+            if (config[0][i].as<std::string>() == "Extended Arms")
+            {
+                try
+                {
+                    info.has_extended_arms = config[1][i].as<bool>();
+                }
+                catch (const std::exception &e)
+                {
+                    std::cout << "Error in robot config variable " << (config[0][i]).as<std::string>() << std::endl;
+                }
+            }
+
+            if (config[0][i].as<std::string>() == "Number of Legs")
+            {
+                try
+                {
+                    info.number_of_legs = config[1][i].as<int>();
+                }
+                catch (const std::exception &e)
+                {
+                    std::cout << "Error in robot config variable " << (config[0][i]).as<std::string>() << std::endl;
+                }
+            }
+
+            if (config[0][i].as<std::string>() == "Number of Arms")
+            {
+                try
+                {
+                    info.number_of_arms = config[1][i].as<int>();
+                }
+                catch (const std::exception &e)
+                {
+                    std::cout << "Error in robot config variable " << (config[0][i]).as<std::string>() << std::endl;
+                }
+            }
+
+            if (config[0][i].as<std::string>() == "Number of Hands")
+            {
+                try
+                {
+                    info.number_of_hands = config[1][i].as<int>();
+                }
+                catch (const std::exception &e)
+                {
+                    std::cout << "Error in robot config variable " << (config[0][i]).as<std::string>() << std::endl;
+                }
+            }
+        }
+    }
+    catch (...)
     {
-      try{
-        info.head_version = config[1][i].as<std::string>();
-      }
-      catch(const std::exception& e)
-      {
-        std::cout << "Error in robot config variable " << (config[0][i]).as<std::string>() << std::endl;
-      }
-    }
+        // NAOqi 2.9
+        std::cout << "ALMotion.getRobotConfig failed (" /*<< e.what()*/ << "), trying with newer service ALRobotModel" << std::endl;
+        auto p_robot_model = session->service("ALRobotModel").value();
 
-    if (config[0][i].as<std::string>() == "Body Version")
-    {
-      try{
-        info.body_version = config[1][i].as<std::string>();
-      }
-      catch(const std::exception& e)
-      {
-        std::cout << "Error in robot config variable " << (config[0][i]).as<std::string>() << std::endl;
-      }
-    }
+        try
+        {
+            info.model = p_robot_model.call<std::string>("getRobotType");
+        }
+        catch (const std::exception &e)
+        {
+            std::cout << "Error getting robot type (with ALRobotModel.getRobotType): " << e.what() << std::endl;
+        }
 
-    if (config[0][i].as<std::string>() == "Arm Version")
-    {
-      try{
-        info.arm_version = config[1][i].as<std::string>();
-      }
-      catch(const std::exception& e)
-      {
-        std::cout << "Error in robot config variable " << (config[0][i]).as<std::string>() << std::endl;
-      }
-    }
+        try
+        {
+            info.number_of_legs = p_robot_model.call<bool>("hasLegs") ? 1 : 0;
+        }
+        catch (const std::exception &e)
+        {
+            std::cout << "Error getting robot type (with ALRobotModel.getRobotType): " << e.what() << std::endl;
+        }
 
-    if (config[0][i].as<std::string>() == "Laser")
-    {
-      try{
-        info.has_laser = config[1][i].as<bool>();
-      }
-      catch(const std::exception& e)
-      {
-        std::cout << "Error in robot config variable " << (config[0][i]).as<std::string>() << std::endl;
-      }
-    }
+        try
+        {
+            std::istringstream config_data(p_robot_model.call<std::string>("getConfig"));
+            pt::ptree tree;
+            pt::read_xml(config_data, tree);
 
-    if (config[0][i].as<std::string>() == "Extended Arms")
-    {
-      try{
-        info.has_extended_arms = config[1][i].as<bool>();
-      }
-      catch(const std::exception& e)
-      {
-        std::cout << "Error in robot config variable " << (config[0][i]).as<std::string>() << std::endl;
-      }
-    }
+            auto preferences = tree.get_child("ModulePreference");
+            for (const auto& pref: preferences) {
+                if (pref.first != "Preference")
+                    continue;
+                const pt::ptree& attributes = pref.second.get_child("<xmlattr>", empty_ptree);
 
-    if (config[0][i].as<std::string>() == "Number of Legs")
-    {
-      try{
-        info.number_of_legs = config[1][i].as<int>();
-      }
-      catch(const std::exception& e)
-      {
-        std::cout << "Error in robot config variable " << (config[0][i]).as<std::string>() << std::endl;
-      }
-    }
+                const auto& memory_key = attributes.get<std::string>("memoryName");
+                if (memory_key == "RobotConfig/Head/Version") {
+                    info.head_version = attributes.get<std::string>("value");
+                } else if (memory_key == "RobotConfig/Body/Version") {
+                    info.body_version = attributes.get<std::string>("value");
+                } else if (memory_key == "RobotConfig/Body/Device/LeftArm/Version") {
+                    info.arm_version = attributes.get<std::string>("value");
+                }
+            }
+        }
+        catch (const std::exception &e)
+        {
+            std::cout << "Error getting head version (with ALRobotModel.getConfig): " << e.what() << std::endl;
+        }
 
-    if (config[0][i].as<std::string>() == "Number of Arms")
-    {
-      try{
-        info.number_of_arms = config[1][i].as<int>();
-      }
-      catch(const std::exception& e)
-      {
-        std::cout << "Error in robot config variable " << (config[0][i]).as<std::string>() << std::endl;
-      }
+        // Some data is missing, but anyways only Pepper 1.8 is supported by NAOqi 2.9.
+        info.has_laser = false;
+        info.has_extended_arms = false;
+        info.number_of_arms = 2;
+        info.number_of_hands = 2;
     }
-
-    if (config[0][i].as<std::string>() == "Number of Hands")
-    {
-      try{
-        info.number_of_hands = config[1][i].as<int>();
-      }
-      catch(const std::exception& e)
-      {
-        std::cout << "Error in robot config variable " << (config[0][i]).as<std::string>() << std::endl;
-      }
-    }
-
-  }
   return info;
 }
 


### PR DESCRIPTION
- Added warning to README for `connection refused error` when trying to connect to robot running naoqi >=2.8
- Added NAOqi 2.9 fixes for driver_helper.cpp from naoqi_driver ROS1 version. Now calls 'ALRobotModel' instead of 'getRobotConfig` when connecting to robot running naoqi >=2.8.

Tested compiled package on ROS Humble + Ubuntu 22.04 + Pepper 1.8 / NAOqi 2.9 with audio features disabled in boot_config.json.