### PR TITLE
ros2_control: ALMotion hardware interface for NAO/Pepper (+ DCM/LoLA plan)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 doc/*
 !doc/source/*
 !doc/Doxyfile
+!doc/ros2_control_test_plan.md
 *.pro
 *.pro.user
 .colcon/

--- a/ASSUMPTIONS.md
+++ b/ASSUMPTIONS.md
@@ -104,6 +104,22 @@ uses, and that velocity control is the real goal. Status of the search:
 - Sources: https://github.com/ros-sports/nao_lola (lola_enums.hpp),
   https://github.com/bhuman/BHumanCodeRelease, https://github.com/NaoHTWK/LolaConnector
 
+### LolaSystem implementation assumptions (verify on a NAO V6)
+
+- **[ASSUMPTION]** The hand-rolled MessagePack codec (`lola_protocol.cpp`)
+  matches real LoLA on the wire. It round-trips against the fake server in CI,
+  which proves self-consistency, not wire-compatibility. Check field names,
+  whether values are float32 vs float64, and map vs array framing on hardware.
+- **[ASSUMPTION]** Sending only `Position` + `Stiffness` in the actuator frame is
+  accepted. LoLA may require all actuator groups (LED fields) every frame; if so,
+  add them to `encodeActuators` (sizes in the table above).
+- **[ASSUMPTION]** One `recv()` returns exactly one LoLA frame (no reassembly).
+  True for small frames in practice; if LoLA fragments, add length-based framing.
+- **[ASSUMPTION]** `RHipYawPitch` shares `LHipYawPitch`'s LoLA slot; commanding
+  both writes the same slot (last wins). Correct only because they are coupled.
+- **[ASSUMPTION]** LoLA has no joint velocity/torque sensor field, so velocity and
+  effort states are left at 0. Could be derived (finite difference) later.
+
 ## libqi runtime from inside controller_manager
 
 - **[ASSUMPTION]** `src/hardware/session_factory.cpp` lazily creates a single

--- a/ASSUMPTIONS.md
+++ b/ASSUMPTIONS.md
@@ -51,6 +51,16 @@ Test harness for confirming these: `test/real_robot_move.sh <ip> [password]`.
   `updateType` is `"ClearAll"` (replace) or `"Merge"`.
 - Source: https://github.com/jrl-umi3218/mc_naoqi_dcm (NAORobotModule.cpp,
   PepperRobotModule.cpp, mc_naoqi_dcm.cpp)
+- **[ASSUMPTION]** `DcmSystem` builds the `createAlias`/`setAlias` arguments as a
+  libqi list of mixed-type `AnyValue`s (the qi equivalent of the old SDK's
+  `ALValue`). mc_naoqi_dcm used the NAOqi C++ SDK (`AL::ALValue`) directly, not
+  libqi. The fake DCM parses our list fine, but that the real DCM accepts a
+  qi-messaging mixed list as an ALValue is untested. Verify on hardware; if it is
+  rejected, wrap values explicitly or call DCM through a different path.
+- **[ASSUMPTION]** `DcmSystem` uses `updateType = "ClearAll"` with a single
+  command timed at `getTime(0)` each cycle. Streaming setpoints this way (replace
+  each cycle) is assumed smooth enough; a real robot may need `"Merge"` with a
+  small future delay. Tune on hardware.
 
 ### Velocity via DCM — THE OPEN QUESTION
 

--- a/ASSUMPTIONS.md
+++ b/ASSUMPTIONS.md
@@ -1,0 +1,113 @@
+# Assumptions to verify on a real robot
+
+This file records facts and assumptions behind the `ros2_control` hardware
+interfaces. Anything marked **[ASSUMPTION]** has *not* been confirmed against a
+real robot and must be tested. **[CONFIRMED: src]** items are backed by an
+authoritative open-source client or by the existing driver code; they are still
+worth re-checking on hardware.
+
+Test harness for confirming these: `test/real_robot_move.sh <ip> [password]`.
+
+## Backend availability matrix
+
+| Robot / NAOqi | State read | Command write | Status |
+|---|---|---|---|
+| NAO 2.1 | ALMemory keys (~83 Hz) | DCM aliases (pos + stiffness, velocity TBD) | planned |
+| Pepper 2.5 | ALMemory keys | DCM aliases (same schema as NAO) | planned |
+| NAO 2.8+ | LoLA socket (~83 Hz) | LoLA socket (pos + stiffness) | planned |
+| Pepper 2.9 | LoLA socket (hidden API) / ALMemory | LoLA (hidden) or ALMotion | planned |
+| any | ALMemory keys | ALMotion `setAngles` (pos) | **implemented** |
+
+- **[ASSUMPTION, expert-asserted]** Pepper 2.9 ships LoLA, just hidden; the API
+  is the same as NAO's. Official Aldebaran docs say LoLA is NAO-only — this
+  contradiction must be resolved on a Pepper 2.9. Unknown: LoLA socket path on
+  Pepper, and Pepper's joint ordering over LoLA (it has different joints + wheels
+  than NAO).
+- **[ASSUMPTION, expert-asserted]** Pepper 2.5 low-level control works like NAO
+  2.1 (DCM). The actuator key *schema* is confirmed identical; what is unverified
+  is that the full flow behaves the same on Pepper 2.5.
+- **[CONFIRMED]** On NAOqi 2.8+, LoLA refreshes ALMemory at only ~2 Hz (vs ~83 Hz
+  before), so fast joint state on 2.8+ must come from the LoLA socket, not from
+  reading ALMemory.
+
+## State (sensor) ALMemory keys — used by AlMotionSystem and the joint_state converter
+
+- **[CONFIRMED: driver]** Position: `Device/SubDeviceList/<Joint>/Position/Sensor/Value`
+- **[CONFIRMED: driver]** Velocity: `Motion/Velocity/Sensor/<Joint>` (an ALMotion
+  key, not a `Device/...` key)
+- **[CONFIRMED: driver]** Torque/effort: `Motion/Torque/Sensor/<Joint>`
+- **[ASSUMPTION]** When a joint has no velocity/torque key (e.g. hands), ALMemory
+  returns void; we map that to 0.0. Confirmed behavior in the fake; assumed on
+  hardware.
+
+## DCM command keys and flow (NAO 2.1 / Pepper 2.5) — for the planned DcmSystem
+
+- **[CONFIRMED: mc_naoqi_dcm]** Position command: `Device/SubDeviceList/<Joint>/Position/Actuator/Value`
+- **[CONFIRMED: mc_naoqi_dcm]** Stiffness command: `Device/SubDeviceList/<Joint>/Hardness/Actuator/Value`
+  (the device key is **"Hardness"**, not "Stiffness")
+- **[CONFIRMED: mc_naoqi_dcm]** Flow: `DCM.createAlias([name, [keys...]])` once,
+  then per cycle: `t = DCM.getTime(0)` and `DCM.setAlias(cmd)` where `cmd` is a
+  size-6 ALValue: `[name, updateType, "time-separate", 0, [t], [[v0],[v1],...]]`.
+  `updateType` is `"ClearAll"` (replace) or `"Merge"`.
+- Source: https://github.com/jrl-umi3218/mc_naoqi_dcm (NAORobotModule.cpp,
+  PepperRobotModule.cpp, mc_naoqi_dcm.cpp)
+
+### Velocity via DCM — THE OPEN QUESTION
+
+The maintainer states the DCM exposes per-joint *target speed* keys that ALMotion
+uses, and that velocity control is the real goal. Status of the search:
+
+- **[CONFIRMED: mc_naoqi_dcm]** Pepper wheels are velocity actuators:
+  `Device/SubDeviceList/Wheel{FL,FR,B}/RotationVelocity/Actuator/Value`. This is
+  the confirmed *pattern* for a velocity actuator key.
+- **[ASSUMPTION / UNRESOLVED]** A per-joint (arm/leg) velocity actuator key was
+  **not** found in open sources. Candidates to probe on a real robot's ALMemory
+  tree (`ALMemory.getDataListName()` filtered by joint name):
+  - `Device/SubDeviceList/<Joint>/ActuatorSpeed/...`
+  - `Device/SubDeviceList/<Joint>/Speed/Actuator/Value`
+  - `Device/SubDeviceList/<Joint>/RotationVelocity/Actuator/Value`
+  ACTION: on a NAO 2.1 / Pepper 2.5, dump the actuator subtree and identify the
+  speed/velocity key the firmware accepts. Until then, DcmSystem will implement
+  position+stiffness; velocity command stays unimplemented.
+
+## LoLA protocol (NAO 2.8+) — for the planned LolaSystem
+
+- **[CONFIRMED: ros-sports/nao_lola, B-Human, rUNSWift, HTWK]**
+  - Socket: AF_UNIX `/tmp/robocup` (created by the `lola` process when
+    `/home/nao/robocup.conf` exists). Serialization: MessagePack map. ~83 Hz / 12 ms.
+  - Actuator map (client→lola): `Position`[25 float], `Stiffness`[25 float],
+    plus LEDs (`Chest`[3], `LEar`[10], `REar`[10], `LEye`[24], `REye`[24],
+    `Skull`[12], `LFoot`[3], `RFoot`[3]).
+  - Sensor map (lola→client): `Position`[25], `Stiffness`[25], `Temperature`[25],
+    `Current`[25], `Status`[25], `Battery`[4], `Accelerometer`[3], `Gyroscope`[3],
+    `Angles`[2], `Sonar`[2], `FSR`[8], `Touch`[14], `RobotConfig`[4 strings].
+  - **Joint order (25, NAO)**: HeadYaw, HeadPitch, LShoulderPitch, LShoulderRoll,
+    LElbowYaw, LElbowRoll, LWristYaw, **LHipYawPitch** (single — L/R coupled),
+    LHipRoll, LHipPitch, LKneePitch, LAnklePitch, LAnkleRoll, RHipRoll, RHipPitch,
+    RKneePitch, RAnklePitch, RAnkleRoll, RShoulderPitch, RShoulderRoll, RElbowYaw,
+    RElbowRoll, RWristYaw, LHand, RHand.
+- **[ASSUMPTION]** LoLA disables ALMotion's control while a custom client owns the
+  socket. The driver's other features (ALMotion-based) may conflict with running
+  LolaSystem simultaneously. Decide co-existence policy on hardware.
+- **[ASSUMPTION]** Pepper's LoLA joint order, socket path, and sensor/actuator
+  field set are unknown (see availability matrix).
+- Sources: https://github.com/ros-sports/nao_lola (lola_enums.hpp),
+  https://github.com/bhuman/BHumanCodeRelease, https://github.com/NaoHTWK/LolaConnector
+
+## libqi runtime from inside controller_manager
+
+- **[ASSUMPTION]** `src/hardware/session_factory.cpp` lazily creates a single
+  `qi::Application` the first time it connects to a real robot, because a
+  pluginlib-loaded hardware interface has no `main()` to own the qi runtime. This
+  is untested. If libqi networking fails without an `ApplicationSession`, the
+  fallback is to create `qi::Application` in a custom controller_manager
+  executable. The emulation path (`createFakeNaoqiSession`) needs none of this.
+
+## ALMotion specifics
+
+- **[CONFIRMED: driver/fake]** `ALMotion.setAngles(names, angles, fractionMaxSpeed)`
+  is position control; `fractionMaxSpeed` ∈ (0,1] is a speed *fraction*, not a
+  velocity. AlMotionSystem therefore exposes a position command only; velocity is
+  state-only.
+- **[ASSUMPTION]** `ALMotion.setStiffnesses("Body", 1.0)` on activation is correct
+  and safe. The fake does not implement it, so failure there is only warned.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,8 @@ set(
   src/hardware/joint_state_keys.cpp
   src/hardware/almotion_system.cpp
   src/hardware/dcm_system.cpp
+  src/hardware/lola_protocol.cpp
+  src/hardware/lola_system.cpp
 )
 add_library(naoqi_driver_hardware SHARED ${HARDWARE_SRC})
 target_include_directories(naoqi_driver_hardware PRIVATE
@@ -247,6 +249,19 @@ if(BUILD_TESTING)
     naoqi_libqi
   )
   target_link_libraries(${PROJECT_NAME}_dcm_test naoqi_driver_hardware)
+
+  ament_add_gtest(${PROJECT_NAME}_lola_test "test/lola_system_test.cpp")
+  target_include_directories(${PROJECT_NAME}_lola_test PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>
+    $<INSTALL_INTERFACE:include>
+  )
+  ament_target_dependencies(${PROJECT_NAME}_lola_test
+    hardware_interface
+    rclcpp
+    rclcpp_lifecycle
+  )
+  target_link_libraries(${PROJECT_NAME}_lola_test naoqi_driver_hardware)
 endif()
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@ find_package(tf2_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(Boost QUIET COMPONENTS chrono filesystem program_options regex system thread random)
+find_package(hardware_interface REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
 
 set(
   CONVERTERS_SRC
@@ -167,8 +170,36 @@ target_link_libraries(naoqi_driver_node
 
 install(TARGETS naoqi_driver_node DESTINATION lib/${PROJECT_NAME})
 
-# install the urdf for runtime loading
+# ros2_control hardware interfaces (loaded by controller_manager via pluginlib).
+# Built as a separate plugin library; reuses the driver lib for the libqi
+# session helpers and the in-process fake NAOqi used in emulation.
+set(
+  HARDWARE_SRC
+  src/hardware/session_factory.cpp
+  src/hardware/almotion_system.cpp
+)
+add_library(naoqi_driver_hardware SHARED ${HARDWARE_SRC})
+target_include_directories(naoqi_driver_hardware PRIVATE
+  "include"
+  "src"
+  ${naoqi_libqi_INCLUDE_DIRS}
+)
+ament_target_dependencies(naoqi_driver_hardware
+  hardware_interface
+  pluginlib
+  rclcpp
+  rclcpp_lifecycle
+  naoqi_libqi
+)
+target_link_libraries(naoqi_driver_hardware naoqi_driver)
+pluginlib_export_plugin_description_file(hardware_interface naoqi_driver_hardware.xml)
+install(TARGETS naoqi_driver_hardware DESTINATION lib)
+
+# install the urdf, ros2_control descriptions and rviz config for runtime loading
 install(DIRECTORY share DESTINATION share/${PROJECT_NAME})
+
+# install the controller configurations
+install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
 
 # install the launch files
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
@@ -184,6 +215,21 @@ if(BUILD_TESTING)
     $<INSTALL_INTERFACE:include>
   )
   target_link_libraries(${PROJECT_NAME}_test naoqi_driver)
+
+  # ros2_control hardware interface, driven against the fake NAOqi.
+  ament_add_gtest(${PROJECT_NAME}_hardware_test "test/almotion_system_test.cpp")
+  target_include_directories(${PROJECT_NAME}_hardware_test PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:include>
+  )
+  ament_target_dependencies(${PROJECT_NAME}_hardware_test
+    hardware_interface
+    rclcpp
+    rclcpp_lifecycle
+    naoqi_libqi
+  )
+  target_link_libraries(${PROJECT_NAME}_hardware_test naoqi_driver_hardware)
 endif()
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ set(
   src/fake_naoqi/fake_naoqi.cpp
   src/fake_naoqi/fake_almotion.cpp
   src/fake_naoqi/fake_almemory.cpp
+  src/fake_naoqi/fake_dcm.cpp
   src/fake_naoqi/fake_services.cpp
 )
 
@@ -176,7 +177,9 @@ install(TARGETS naoqi_driver_node DESTINATION lib/${PROJECT_NAME})
 set(
   HARDWARE_SRC
   src/hardware/session_factory.cpp
+  src/hardware/joint_state_keys.cpp
   src/hardware/almotion_system.cpp
+  src/hardware/dcm_system.cpp
 )
 add_library(naoqi_driver_hardware SHARED ${HARDWARE_SRC})
 target_include_directories(naoqi_driver_hardware PRIVATE
@@ -230,6 +233,20 @@ if(BUILD_TESTING)
     naoqi_libqi
   )
   target_link_libraries(${PROJECT_NAME}_hardware_test naoqi_driver_hardware)
+
+  ament_add_gtest(${PROJECT_NAME}_dcm_test "test/dcm_system_test.cpp")
+  target_include_directories(${PROJECT_NAME}_dcm_test PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+    $<INSTALL_INTERFACE:include>
+  )
+  ament_target_dependencies(${PROJECT_NAME}_dcm_test
+    hardware_interface
+    rclcpp
+    rclcpp_lifecycle
+    naoqi_libqi
+  )
+  target_link_libraries(${PROJECT_NAME}_dcm_test naoqi_driver_hardware)
 endif()
 
 ament_package()

--- a/CURRENT_PLAN.md
+++ b/CURRENT_PLAN.md
@@ -52,11 +52,15 @@ the baseline. Velocity is pursued through DCM speed keys — see ASSUMPTIONS.md,
   and URDF<->LoLA 25-joint mapping (RHipYawPitch aliases LHipYawPitch). Tested
   against a fake LoLA Unix-socket server (`test/fake_lola_server.hpp`).
 - Wiring: pluginlib export (`naoqi_driver_hardware.xml`, all three classes), reusable
-  `naoqi_system.ros2_control.xacro` macro + `nao.urdf.xacro` (plugin selectable),
-  `config/nao_controllers.yaml`, `launch/ros2_control.launch.py`.
+  `naoqi_system.ros2_control.xacro` macro, `nao.urdf.xacro` + `pepper.urdf.xacro`
+  (plugin + robot selectable), `config/{nao,pepper}_controllers.yaml`,
+  `launch/ros2_control.launch.py` (`robot:=nao|pepper`).
+- Pepper description: 17 articular joints (head, arms, hip, knee). The holonomic
+  base (WheelFL/FR/B, velocity-controlled) stays on the driver's `/cmd_vel`
+  subscriber (ALMotion.move), not exposed as ros2_control joints.
 - Tests: emulation gtests `test/almotion_system_test.cpp`,
-  `test/dcm_system_test.cpp`; human real-robot `test/real_robot_move.sh`
-  (works with any plugin via its 3rd arg).
+  `test/dcm_system_test.cpp`, `test/lola_system_test.cpp`; human real-robot
+  `test/real_robot_move.sh` (any plugin via arg 3, `nao`/`pepper` via arg 4).
 
 ### Next (real-robot validation)
 1. Verify the hand-rolled MessagePack matches real LoLA on a NAO V6 (field
@@ -66,8 +70,8 @@ the baseline. Velocity is pursued through DCM speed keys — see ASSUMPTIONS.md,
    set `velocity_actuator_key` and validate velocity command (ASSUMPTIONS.md).
 3. Verify on a real robot that a mixed-type libqi list is accepted by the real
    DCM as an ALValue (the emulator parses it; hardware is untested).
-4. Pepper description (`pepper.urdf.xacro`) with its joint set (+ wheels via a
-   separate velocity interface / cmd_vel).
+4. Optional: expose Pepper's wheels as a velocity ros2_control interface (omni
+   base controller) instead of / alongside `/cmd_vel`.
 5. Decide co-existence between a running naoqi_driver node and a ros2_control
    backend (both talk to the robot).
 

--- a/CURRENT_PLAN.md
+++ b/CURRENT_PLAN.md
@@ -46,16 +46,22 @@ the baseline. Velocity is pursued through DCM speed keys — see ASSUMPTIONS.md,
   `dcm_system.*`, DCM `createAlias`/`getTime`/`setAlias`. Each joint declares
   one command interface (position XOR velocity); velocity needs the
   `velocity_actuator_key` param. `FakeDCM` added to the fake NAOqi.
-- Wiring: pluginlib export (`naoqi_driver_hardware.xml`, both classes), reusable
+- `LolaSystem` (position + stiffness) — `lola_system.*`, AF_UNIX `/tmp/robocup`,
+  hand-rolled MessagePack codec (`lola_protocol.*`, no msgpack dependency), a
+  background IO thread decoupling the 83 Hz LoLA cycle from controller_manager,
+  and URDF<->LoLA 25-joint mapping (RHipYawPitch aliases LHipYawPitch). Tested
+  against a fake LoLA Unix-socket server (`test/fake_lola_server.hpp`).
+- Wiring: pluginlib export (`naoqi_driver_hardware.xml`, all three classes), reusable
   `naoqi_system.ros2_control.xacro` macro + `nao.urdf.xacro` (plugin selectable),
   `config/nao_controllers.yaml`, `launch/ros2_control.launch.py`.
 - Tests: emulation gtests `test/almotion_system_test.cpp`,
   `test/dcm_system_test.cpp`; human real-robot `test/real_robot_move.sh`
   (works with any plugin via its 3rd arg).
 
-### Next
-1. `LolaSystem`: MessagePack client over `/tmp/robocup` (fields/order in
-   ASSUMPTIONS.md). Add a fake LoLA Unix-socket server for CI. Verify Pepper 2.9.
+### Next (real-robot validation)
+1. Verify the hand-rolled MessagePack matches real LoLA on a NAO V6 (field
+   names, float widths, whether LoLA requires LED groups in every actuator
+   frame). Confirm `/tmp/robocup` and that LoLA exists/socket path on Pepper 2.9.
 2. Resolve the DCM per-joint velocity key on a real NAO 2.1 / Pepper 2.5, then
    set `velocity_actuator_key` and validate velocity command (ASSUMPTIONS.md).
 3. Verify on a real robot that a mixed-type libqi list is accepted by the real

--- a/CURRENT_PLAN.md
+++ b/CURRENT_PLAN.md
@@ -1,0 +1,76 @@
+# Plan: ros2_control for NAO and Pepper
+
+## Goal
+
+Expose NAO/Pepper joints through `ros2_control` so standard controllers
+(joint_state_broadcaster, joint_trajectory_controller, forward controllers) can
+drive the robot. Cover every NAOqi generation by selecting the right transport,
+and keep everything testable without a robot via the in-process fake NAOqi from
+the `fake_naoqi` study this branch builds on.
+
+## Design
+
+`ros2_control`'s unit is a `SystemInterface` plugin loaded by
+`controller_manager`. The three transports to the robot are genuinely different
+concerns, so each is its own plugin, selected in the URDF `<hardware><plugin>`
+(no internal backend switching). They share connection parameters; each ignores
+the ones it does not need.
+
+| Plugin | Transport | Targets | Command | Runs |
+|---|---|---|---|---|
+| `naoqi_driver/AlMotionSystem` | libqi → ALMotion | NAOqi 2.1–2.9 (universal) | position | anywhere |
+| `naoqi_driver/DcmSystem` | libqi → DCM + ALMemory | NAO 2.1, Pepper 2.5 | position (+velocity TBD) | anywhere |
+| `naoqi_driver/LolaSystem` | `/tmp/robocup` socket | NAO 2.8+, Pepper 2.9 (hidden) | position | on the robot |
+
+Shared pieces:
+- `src/hardware/session_factory.*` — builds a libqi session (real or fake) from
+  ros2_control params. Reused by ALMotion and DCM systems.
+- State is read from ALMemory with the same keys as the `joint_state` converter.
+
+Velocity: none of the transports offer a native joint velocity *command*
+(ALMotion's speed is a fraction; LoLA/DCM are position+stiffness). Position is
+the baseline. Velocity is pursued through DCM speed keys — see ASSUMPTIONS.md,
+"Velocity via DCM", which is the main open research item.
+
+## Status
+
+### Done
+- Branch based on the `fake_naoqi` study (fake ALMemory/ALMotion/services,
+  emulation mode, ALMemory-key state path).
+- `AlMotionSystem` (position) implemented end-to-end:
+  - `src/hardware/almotion_system.*`, `src/hardware/session_factory.*`
+  - pluginlib export `naoqi_driver_hardware.xml`, CMake/package.xml wiring
+  - description `share/ros2_control/nao.urdf.xacro` + reusable
+    `naoqi_system.ros2_control.xacro` macro
+  - controllers `config/nao_controllers.yaml`, bringup
+    `launch/ros2_control.launch.py`
+  - emulation gtest `test/almotion_system_test.cpp`
+  - human real-robot test `test/real_robot_move.sh`
+
+### Next
+1. Resolve the DCM joint-velocity key on a real NAO 2.1 / Pepper 2.5
+   (ASSUMPTIONS.md). Until then, no velocity command.
+2. `DcmSystem`: `DCM.createAlias` for position + Hardness aliases; per-cycle
+   `getTime`/`setAlias`. Add a `FakeDCM` to the fake NAOqi so it is CI-testable.
+   Add velocity once the key is known.
+3. `LolaSystem`: MessagePack client over `/tmp/robocup` (fields/order in
+   ASSUMPTIONS.md). Add a fake LoLA Unix-socket server for CI. Verify Pepper 2.9.
+4. Pepper description (`pepper.urdf.xacro`) with its joint set (+ wheels via a
+   separate velocity interface / cmd_vel).
+5. Decide co-existence between a running naoqi_driver node and a ros2_control
+   backend (both talk to the robot).
+
+## How to test
+
+```bash
+# Emulation (no robot): unit test
+colcon test --packages-select naoqi_driver --ctest-args -R naoqi_driver_hardware_test
+
+# Emulation: full stack
+ros2 launch naoqi_driver ros2_control.launch.py emulation_mode:=true
+ros2 control list_controllers
+ros2 topic echo /joint_states --once
+
+# Real robot (human verification)
+./src/naoqi_driver/test/real_robot_move.sh <robot_ip> [password]
+```

--- a/CURRENT_PLAN.md
+++ b/CURRENT_PLAN.md
@@ -37,24 +37,29 @@ the baseline. Velocity is pursued through DCM speed keys — see ASSUMPTIONS.md,
 ### Done
 - Branch based on the `fake_naoqi` study (fake ALMemory/ALMotion/services,
   emulation mode, ALMemory-key state path).
-- `AlMotionSystem` (position) implemented end-to-end:
-  - `src/hardware/almotion_system.*`, `src/hardware/session_factory.*`
-  - pluginlib export `naoqi_driver_hardware.xml`, CMake/package.xml wiring
-  - description `share/ros2_control/nao.urdf.xacro` + reusable
-    `naoqi_system.ros2_control.xacro` macro
-  - controllers `config/nao_controllers.yaml`, bringup
-    `launch/ros2_control.launch.py`
-  - emulation gtest `test/almotion_system_test.cpp`
-  - human real-robot test `test/real_robot_move.sh`
+- Shared `src/hardware/`:
+  - `session_factory.*` — libqi session (real/fake) from ros2_control params
+  - `joint_state_keys.*` — ALMemory state keys + batched read, used by both
+    libqi backends
+- `AlMotionSystem` (position) — `almotion_system.*`, `ALMotion.setAngles`.
+- `DcmSystem` (position + stiffness; velocity ready behind a key param) —
+  `dcm_system.*`, DCM `createAlias`/`getTime`/`setAlias`. Each joint declares
+  one command interface (position XOR velocity); velocity needs the
+  `velocity_actuator_key` param. `FakeDCM` added to the fake NAOqi.
+- Wiring: pluginlib export (`naoqi_driver_hardware.xml`, both classes), reusable
+  `naoqi_system.ros2_control.xacro` macro + `nao.urdf.xacro` (plugin selectable),
+  `config/nao_controllers.yaml`, `launch/ros2_control.launch.py`.
+- Tests: emulation gtests `test/almotion_system_test.cpp`,
+  `test/dcm_system_test.cpp`; human real-robot `test/real_robot_move.sh`
+  (works with any plugin via its 3rd arg).
 
 ### Next
-1. Resolve the DCM joint-velocity key on a real NAO 2.1 / Pepper 2.5
-   (ASSUMPTIONS.md). Until then, no velocity command.
-2. `DcmSystem`: `DCM.createAlias` for position + Hardness aliases; per-cycle
-   `getTime`/`setAlias`. Add a `FakeDCM` to the fake NAOqi so it is CI-testable.
-   Add velocity once the key is known.
-3. `LolaSystem`: MessagePack client over `/tmp/robocup` (fields/order in
+1. `LolaSystem`: MessagePack client over `/tmp/robocup` (fields/order in
    ASSUMPTIONS.md). Add a fake LoLA Unix-socket server for CI. Verify Pepper 2.9.
+2. Resolve the DCM per-joint velocity key on a real NAO 2.1 / Pepper 2.5, then
+   set `velocity_actuator_key` and validate velocity command (ASSUMPTIONS.md).
+3. Verify on a real robot that a mixed-type libqi list is accepted by the real
+   DCM as an ALValue (the emulator parses it; hardware is untested).
 4. Pepper description (`pepper.urdf.xacro`) with its joint set (+ wheels via a
    separate velocity interface / cmd_vel).
 5. Decide co-existence between a running naoqi_driver node and a ros2_control

--- a/README.md
+++ b/README.md
@@ -257,6 +257,64 @@ angular:
 ```
 
 
+## ros2_control
+
+Beyond the topic-based interface above, the driver provides
+[`ros2_control`](https://control.ros.org) hardware interfaces, so standard
+controllers (e.g. `joint_trajectory_controller`) can drive the robot's joints.
+Three `SystemInterface` plugins cover the different NAOqi generations; you pick
+one in the URDF (or via the `plugin:=` launch argument):
+
+| Plugin | Transport | Robots / NAOqi | Command |
+|--------|-----------|----------------|---------|
+| `naoqi_driver/AlMotionSystem` | libqi → ALMotion | any (NAOqi 2.1–2.9); required on Pepper 2.9 | position |
+| `naoqi_driver/DcmSystem` | libqi → DCM | NAO 2.1, Pepper 2.5 | position + stiffness |
+| `naoqi_driver/LolaSystem` | local `/tmp/robocup` socket | NAO 2.8+, Pepper 2.9; must run **on the robot** | position + stiffness |
+
+Position command is the supported baseline on every backend; velocity is
+exposed as a state only (work in progress for the DCM backend). See
+[`ASSUMPTIONS.md`](ASSUMPTIONS.md) for what is verified versus assumed per robot.
+
+### Try it without a robot (emulation)
+
+```sh
+ros2 launch naoqi_driver ros2_control.launch.py emulation_mode:=true
+ros2 control list_controllers          # joint_state_broadcaster + trajectory controller, active
+ros2 topic echo /joint_states --once
+```
+
+Move the head through the trajectory controller:
+
+```sh
+ros2 action send_goal /nao_joint_trajectory_controller/follow_joint_trajectory \
+  control_msgs/action/FollowJointTrajectory \
+  "{trajectory: {joint_names: [HeadYaw], points: [{positions: [0.3], time_from_start: {sec: 2}}]}}"
+```
+
+### On a real robot
+
+Select the robot, backend and connection. For example, ALMotion on a Pepper:
+
+```sh
+ros2 launch naoqi_driver ros2_control.launch.py \
+  robot:=pepper plugin:=naoqi_driver/AlMotionSystem \
+  nao_ip:=<robot_host> password:=<robot_password>
+```
+
+> `robot:=` selects the description and controllers (`nao` or `pepper`).
+> `plugin:=` selects the backend. `LolaSystem` only works when the driver runs
+> on the robot itself.
+
+There is also a one-shot human-verification test that nods the head:
+
+```sh
+./src/naoqi_driver/test/real_robot_move.sh <robot_ip> [password] [plugin] [nao|pepper]
+```
+
+A full validation procedure (emulation and on-robot, per backend) is in
+[`doc/ros2_control_test_plan.md`](doc/ros2_control_test_plan.md).
+
+
 ## Development
 
 Check how to [install the driver from source](#installing-from-source),

--- a/config/nao_controllers.yaml
+++ b/config/nao_controllers.yaml
@@ -1,0 +1,47 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 50  # Hz
+
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+
+    nao_joint_trajectory_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+
+nao_joint_trajectory_controller:
+  ros__parameters:
+    joints:
+      - HeadYaw
+      - HeadPitch
+      - LShoulderPitch
+      - LShoulderRoll
+      - LElbowYaw
+      - LElbowRoll
+      - LWristYaw
+      - LHand
+      - RShoulderPitch
+      - RShoulderRoll
+      - RElbowYaw
+      - RElbowRoll
+      - RWristYaw
+      - RHand
+      - LHipYawPitch
+      - LHipRoll
+      - LHipPitch
+      - LKneePitch
+      - LAnklePitch
+      - LAnkleRoll
+      - RHipYawPitch
+      - RHipRoll
+      - RHipPitch
+      - RKneePitch
+      - RAnklePitch
+      - RAnkleRoll
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+      - velocity
+    # Allow sending goals for a subset of joints (e.g. just the head); the
+    # controller holds the others at their current position.
+    allow_partial_joints_goal: true

--- a/config/pepper_controllers.yaml
+++ b/config/pepper_controllers.yaml
@@ -1,0 +1,38 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 50  # Hz
+
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+
+    pepper_joint_trajectory_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+
+pepper_joint_trajectory_controller:
+  ros__parameters:
+    joints:
+      - HeadYaw
+      - HeadPitch
+      - LShoulderPitch
+      - LShoulderRoll
+      - LElbowYaw
+      - LElbowRoll
+      - LWristYaw
+      - LHand
+      - RShoulderPitch
+      - RShoulderRoll
+      - RElbowYaw
+      - RElbowRoll
+      - RWristYaw
+      - RHand
+      - HipRoll
+      - HipPitch
+      - KneePitch
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+      - velocity
+    # Allow sending goals for a subset of joints (e.g. just the head); the
+    # controller holds the others at their current position.
+    allow_partial_joints_goal: true

--- a/doc/ros2_control_test_plan.md
+++ b/doc/ros2_control_test_plan.md
@@ -1,0 +1,254 @@
+# ros2_control Test Plan — NAO / Pepper
+
+This plan validates the `ros2_control` hardware interfaces (`AlMotionSystem`,
+`DcmSystem`, `LolaSystem`). It is layered: Level 1 runs in CI with no robot,
+Level 2 is a manual emulation smoke test, and Level 3 is the on-robot procedure
+a human runs to confirm motion and to resolve the open assumptions in
+[`../ASSUMPTIONS.md`](../ASSUMPTIONS.md).
+
+> Safety: on a real robot, always clear space around it, disable autonomous
+> life, and keep the emergency stop / chest button reachable. Joints become stiff
+> when a controller activates.
+
+## Backend / robot coverage
+
+| Backend | NAO 2.1 | NAO 2.8+ | Pepper 2.5 | Pepper 2.9 | Runs |
+|---------|:-------:|:--------:|:----------:|:----------:|------|
+| `AlMotionSystem` | ✓ | ✓ | ✓ | ✓ (required) | remote or on-robot |
+| `DcmSystem` | ✓ | — (DCM removed) | ✓ | — | remote or on-robot |
+| `LolaSystem` | — | ✓ | — | ✓ (hidden) | on-robot only |
+
+A "✓" is a configuration we intend to support; whether it works is exactly what
+Level 3 confirms.
+
+## Prerequisites
+
+- A built, sourced workspace (`source install/setup.bash`).
+- For Level 3: the robot's IP, and for NAOqi ≥ 2.9 a password. Network reachable.
+- Recommended robot prep:
+  ```sh
+  ssh nao@<robot_host>
+  qicli call ALAutonomousLife.setState disabled
+  qicli call ALMotion.wakeUp
+  ```
+
+---
+
+## Level 1 — Automated emulation tests (CI, no robot)
+
+These run on every push (`colcon test`) and gate the PR. Each drives a hardware
+interface through its full lifecycle against an in-process fake and asserts a
+commanded position is read back.
+
+| Test | Exercises |
+|------|-----------|
+| `naoqi_driver_hardware_test` | `AlMotionSystem` via fake ALMotion + ALMemory |
+| `naoqi_driver_dcm_test` | `DcmSystem` via fake DCM (alias flow) + ALMemory |
+| `naoqi_driver_lola_test` | `LolaSystem` via a fake `/tmp/robocup` server + the MessagePack codec |
+
+Run locally:
+
+```sh
+colcon test --packages-select naoqi_driver \
+  --ctest-args -R "hardware_test|dcm_test|lola_test"
+colcon test-result --verbose
+```
+
+**Pass:** all three tests report `HeadYaw` reaching the commanded `0.5 rad`, and
+the LoLA codec round-trip matches to `1e-6`.
+
+**Limit:** these prove the *plumbing and our own codec are self-consistent*; they
+do **not** prove wire-compatibility with a real robot. That is Level 3.
+
+---
+
+## Level 2 — Emulation integration (manual, no robot)
+
+Confirms the launch, URDF/xacro, controllers and joint mapping wire up together.
+
+```sh
+# NAO (default)
+ros2 launch naoqi_driver ros2_control.launch.py emulation_mode:=true
+# Pepper
+ros2 launch naoqi_driver ros2_control.launch.py emulation_mode:=true robot:=pepper
+```
+
+In another shell:
+
+```sh
+ros2 control list_hardware_interfaces      # position command + pos/vel/effort state per joint
+ros2 control list_controllers              # broadcaster + <robot>_joint_trajectory_controller : active
+ros2 topic hz /joint_states                # ~update_rate (50 Hz)
+ros2 action send_goal /nao_joint_trajectory_controller/follow_joint_trajectory \
+  control_msgs/action/FollowJointTrajectory \
+  "{trajectory: {joint_names: [HeadYaw], points: [{positions: [0.3], time_from_start: {sec: 2}}]}}"
+ros2 topic echo /joint_states --once       # HeadYaw position tracks toward 0.3
+```
+
+**Pass:** controllers reach `active`, `/joint_states` publishes all joints at the
+configured rate, and a trajectory goal succeeds with the state tracking the
+target. Repeat with `robot:=pepper` (17 joints, no wheels).
+
+---
+
+## Level 3 — On-robot tests (human verification)
+
+The quickest end-to-end check, for any backend:
+
+```sh
+./src/naoqi_driver/test/real_robot_move.sh <robot_ip> [password] <plugin> <nao|pepper>
+```
+
+It brings up the stack, waits for the controller to activate, and commands a
+small head nod (`HeadYaw` → +0.3 → 0). **Observe the head physically move.**
+
+The per-backend procedures below go further and capture the data needed to close
+the open assumptions.
+
+### 3.0 General checklist (every backend)
+
+1. Robot prepped (autonomous life disabled, `wakeUp`), space cleared.
+2. Launch with the right `robot:=`, `plugin:=`, and connection args.
+3. `ros2 control list_controllers` → both controllers `active`.
+4. `ros2 topic echo /joint_states` shows **plausible, live** angles (matches the
+   robot's actual pose; move a limb by hand with low stiffness and watch it
+   change).
+5. Send a small head trajectory; confirm motion matches the command direction
+   and magnitude (no inversion, no scaling error).
+6. On `Ctrl-C`, the robot does not jerk.
+
+### 3.1 ALMotion (`naoqi_driver/AlMotionSystem`) — any robot
+
+Baseline; should "just work" over the network.
+
+```sh
+ros2 launch naoqi_driver ros2_control.launch.py \
+  robot:=<nao|pepper> plugin:=naoqi_driver/AlMotionSystem \
+  nao_ip:=<robot_host> password:=<password>
+```
+
+- Run 3.0.
+- Sweep one joint slowly across part of its range; verify smoothness and that
+  `/joint_states` tracks within a small lag.
+- **Record:** does `setStiffnesses` on activation hold the limb against gravity?
+  Any joints that refuse to move (e.g. hands)?
+
+### 3.2 DCM (`naoqi_driver/DcmSystem`) — NAO 2.1 / Pepper 2.5
+
+Low-level position + stiffness. Validates the `createAlias`/`setAlias` flow over
+libqi.
+
+```sh
+ros2 launch naoqi_driver ros2_control.launch.py \
+  robot:=<nao|pepper> plugin:=naoqi_driver/DcmSystem \
+  nao_ip:=<robot_host>
+```
+
+- Run 3.0.
+- **Resolve [DCM ALValue]:** confirm the driver does not error on
+  `createAlias`/`setAlias`. If it throws, the real DCM rejected our libqi
+  mixed-type list; capture the exact error.
+- **Resolve [DCM velocity key]** (the main open item): on the robot, dump the
+  actuator subtree and look for a per-joint speed actuator:
+  ```sh
+  qicli call ALMemory.getDataListName | grep -iE "HeadYaw.*(Speed|Velocity|Actuator)"
+  ```
+  Candidates to try as `velocity_actuator_key` (with `{}` = joint name):
+  `Device/SubDeviceList/{}/Speed/Actuator/Value`,
+  `Device/SubDeviceList/{}/ActuatorSpeed/Value`,
+  `Device/SubDeviceList/{}/RotationVelocity/Actuator/Value`.
+  For each candidate, build a velocity-command URDF and check whether commanding
+  a small constant velocity produces steady motion:
+  ```sh
+  ros2 launch naoqi_driver ros2_control.launch.py robot:=nao \
+    plugin:=naoqi_driver/DcmSystem nao_ip:=<host> \
+    velocity_actuator_key:='Device/SubDeviceList/{}/Speed/Actuator/Value'
+  ```
+  **Record** which key (if any) the firmware accepts and moves on.
+- **Cross-check** DCM vs ALMotion: same commanded angle should reach the same
+  measured angle.
+
+### 3.3 LoLA (`naoqi_driver/LolaSystem`) — NAO 2.8+ (and Pepper 2.9, hidden)
+
+Must run **on the robot**. Validates the socket, MessagePack codec and joint
+mapping.
+
+Preconditions on the robot:
+- `/home/nao/robocup.conf` exists (may be empty) so the `lola` process creates
+  `/tmp/robocup`.
+- No other LoLA client (B-Human, etc.) is holding the socket.
+
+```sh
+# on the robot
+ros2 launch naoqi_driver ros2_control.launch.py \
+  robot:=nao plugin:=naoqi_driver/LolaSystem
+```
+
+- Run 3.0.
+- **Resolve [LoLA wire-format]:** the most likely failure is a decode mismatch.
+  If `/joint_states` is empty/garbage, capture one raw frame and compare against
+  `lola_protocol.cpp`:
+  ```sh
+  # on the robot, with our client stopped
+  python3 - <<'PY'
+  import socket, pprint
+  try:
+      import msgpack
+  except ImportError:
+      msgpack = None
+  s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM); s.connect("/tmp/robocup")
+  data = s.recv(2048); s.close()
+  print("len", len(data))
+  if msgpack: pprint.pprint(msgpack.unpackb(data, raw=False))
+  PY
+  ```
+  **Record:** the field names, whether floats are 32- or 64-bit, the `Position`
+  array length/order, and whether the server rejects an actuator frame that
+  omits LED groups (`Chest`, `LEye`, …). Feed corrections back into
+  `encodeActuators`/`decodeSensors` and the LoLA section of `ASSUMPTIONS.md`.
+- **Resolve [Pepper LoLA]:** on a Pepper 2.9, check whether `/tmp/robocup`
+  exists and what joint order it uses (Pepper's joints differ from NAO; the
+  current `jointOrder()` is NAO's).
+- **Rate check:** `ros2 topic hz /joint_states` should approach LoLA's ~83 Hz
+  if the controller_manager `update_rate` is set high enough.
+
+---
+
+## Assumption → test mapping
+
+Each open item in [`../ASSUMPTIONS.md`](../ASSUMPTIONS.md) is resolved by a
+specific step here:
+
+| Assumption | Resolved by | Capture |
+|------------|-------------|---------|
+| libqi runtime usable from controller_manager | 3.1 launch succeeds | does any backend connect to a real robot at all? |
+| DCM accepts libqi mixed-type ALValue | 3.2 | exact error, or success |
+| Per-joint DCM velocity key | 3.2 velocity probe | the accepted key, or "none exists" |
+| `ClearAll` vs `Merge` smoothness | 3.2 sweep | jitter at command rate? |
+| LoLA wire format (fields, float width, framing) | 3.3 frame capture | corrected codec |
+| LoLA needs LED groups every frame | 3.3 | does the server stall if omitted? |
+| Pepper 2.9 has LoLA; its socket/joint order | 3.3 (Pepper) | socket presence + order |
+| ALMotion `setStiffnesses` correctness | 3.1 | holds against gravity? |
+
+## Pass / fail criteria
+
+- **Level 1/2:** all automated tests green; controllers active; `/joint_states`
+  live; trajectory goals tracked.
+- **Level 3 (per backend):** the robot moves as commanded (correct direction and
+  magnitude), state tracks command, no unexpected jerk on start/stop, and the
+  assumptions in scope for that backend are recorded as confirmed or corrected.
+
+## Results log (copy per run)
+
+```
+date / tester:
+robot + NAOqi version:
+backend (plugin):           run location (remote / on-robot):
+Level 1 tests:              pass / fail (notes)
+Level 2 emulation:          pass / fail (notes)
+Level 3 head nod:           moved? y/n
+Level 3 backend specifics:  (DCM velocity key found? LoLA frame matches? ...)
+assumptions confirmed:
+assumptions corrected:      (and the code/doc change made)
+issues / follow-ups:
+```

--- a/include/naoqi_driver/hardware/almotion_system.hpp
+++ b/include/naoqi_driver/hardware/almotion_system.hpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef NAOQI_DRIVER_HARDWARE_ALMOTION_SYSTEM_HPP
+#define NAOQI_DRIVER_HARDWARE_ALMOTION_SYSTEM_HPP
+
+#include <string>
+#include <vector>
+
+#include <qi/anyobject.hpp>
+#include <qi/session.hpp>
+
+#include "hardware_interface/system_interface.hpp"
+#include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "rclcpp_lifecycle/state.hpp"
+
+namespace naoqi
+{
+namespace hardware
+{
+
+/// ros2_control SystemInterface driving joints through NAOqi's high-level
+/// ALMotion service over libqi.
+///
+/// Works on every NAOqi version reachable over the network (2.1 through 2.9),
+/// which makes it the universal fallback and the only joint-control path left
+/// on Pepper 2.9. It is position-only: ALMotion exposes setAngles(names, angles,
+/// speed) where speed is a fraction of the joint's max speed, not a velocity
+/// command. Velocity is published as a state interface but cannot be commanded
+/// here; use the DCM or LoLA systems for that.
+///
+/// State is read from ALMemory in one batched getListData call, using the same
+/// keys as the joint_state converter:
+///   Device/SubDeviceList/<Joint>/Position/Sensor/Value
+///   Motion/Velocity/Sensor/<Joint>
+///   Motion/Torque/Sensor/<Joint>
+class AlMotionSystem : public hardware_interface::SystemInterface
+{
+  public:
+  hardware_interface::CallbackReturn on_init(const hardware_interface::HardwareInfo& info) override;
+
+  hardware_interface::CallbackReturn
+  on_configure(const rclcpp_lifecycle::State& previous_state) override;
+
+  hardware_interface::CallbackReturn
+  on_cleanup(const rclcpp_lifecycle::State& previous_state) override;
+
+  std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
+  std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
+
+  hardware_interface::CallbackReturn
+  on_activate(const rclcpp_lifecycle::State& previous_state) override;
+  hardware_interface::CallbackReturn
+  on_deactivate(const rclcpp_lifecycle::State& previous_state) override;
+
+  hardware_interface::return_type read(const rclcpp::Time& time,
+                                       const rclcpp::Duration& period) override;
+  hardware_interface::return_type write(const rclcpp::Time& time,
+                                        const rclcpp::Duration& period) override;
+
+  private:
+  std::vector<std::string> joint_names_;
+
+  // State, indexed like joint_names_.
+  std::vector<double> positions_;
+  std::vector<double> velocities_;
+  std::vector<double> efforts_;
+
+  // Position command, indexed like joint_names_.
+  std::vector<double> position_commands_;
+
+  // ALMemory keys, laid out [positions..., velocities..., torques...].
+  std::vector<std::string> memory_keys_;
+
+  // Fraction of each joint's maximum speed used to reach the commanded
+  // position (the ALMotion setAngles "fractionMaxSpeed" argument), in (0, 1].
+  double max_velocity_fraction_ = 0.1;
+
+  qi::SessionPtr session_;
+  qi::AnyObject motion_;
+  qi::AnyObject memory_;
+};
+
+}  // namespace hardware
+}  // namespace naoqi
+
+#endif  // NAOQI_DRIVER_HARDWARE_ALMOTION_SYSTEM_HPP

--- a/include/naoqi_driver/hardware/dcm_system.hpp
+++ b/include/naoqi_driver/hardware/dcm_system.hpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2025 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef NAOQI_DRIVER_HARDWARE_DCM_SYSTEM_HPP
+#define NAOQI_DRIVER_HARDWARE_DCM_SYSTEM_HPP
+
+#include <string>
+#include <vector>
+
+#include <qi/anyobject.hpp>
+#include <qi/session.hpp>
+
+#include "hardware_interface/system_interface.hpp"
+#include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "rclcpp_lifecycle/state.hpp"
+
+namespace naoqi
+{
+namespace hardware
+{
+
+/// ros2_control SystemInterface driving joints through NAOqi's DCM (Device
+/// Communication Manager) over libqi, the low-level path on robots where the
+/// DCM is still exposed: NAO 2.1 and Pepper 2.5.
+///
+/// Commands are written to ALMemory actuator keys via the DCM alias mechanism:
+///   createAlias([name, [keys]]) once, then per cycle getTime(0) + setAlias.
+/// Position: Device/SubDeviceList/<Joint>/Position/Actuator/Value
+/// Stiffness: Device/SubDeviceList/<Joint>/Hardness/Actuator/Value
+///
+/// Command mode is chosen from the URDF: each joint declares exactly one
+/// command interface, either "position" or "velocity", and all joints must
+/// agree. Velocity requires the velocity_actuator_key hardware parameter (the
+/// per-joint DCM speed key is not confirmed in public sources; see
+/// ASSUMPTIONS.md). State is read from ALMemory like the ALMotion system.
+class DcmSystem : public hardware_interface::SystemInterface
+{
+  public:
+  hardware_interface::CallbackReturn on_init(const hardware_interface::HardwareInfo& info) override;
+
+  hardware_interface::CallbackReturn
+  on_configure(const rclcpp_lifecycle::State& previous_state) override;
+
+  hardware_interface::CallbackReturn
+  on_cleanup(const rclcpp_lifecycle::State& previous_state) override;
+
+  std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
+  std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
+
+  hardware_interface::CallbackReturn
+  on_activate(const rclcpp_lifecycle::State& previous_state) override;
+  hardware_interface::CallbackReturn
+  on_deactivate(const rclcpp_lifecycle::State& previous_state) override;
+
+  hardware_interface::return_type read(const rclcpp::Time& time,
+                                       const rclcpp::Duration& period) override;
+  hardware_interface::return_type write(const rclcpp::Time& time,
+                                        const rclcpp::Duration& period) override;
+
+  private:
+  enum class CommandMode
+  {
+    POSITION,
+    VELOCITY
+  };
+
+  /// Registers a DCM alias grouping the given actuator keys. Throws on qi error.
+  void createAlias(const std::string& name, const std::vector<std::string>& keys);
+  /// Writes one timed value per actuator of the alias at the current DCM time.
+  void setAlias(const std::string& name, const std::vector<float>& values);
+
+  std::vector<std::string> joint_names_;
+
+  std::vector<double> positions_;
+  std::vector<double> velocities_;
+  std::vector<double> efforts_;
+  std::vector<double> commands_;  // position or velocity, per command_mode_
+
+  std::vector<std::string> memory_keys_;     // state, see jointStateKeys()
+  std::vector<std::string> position_keys_;   // Position/Actuator/Value
+  std::vector<std::string> stiffness_keys_;  // Hardness/Actuator/Value
+  std::vector<std::string> velocity_keys_;   // from velocity_actuator_key param
+
+  CommandMode command_mode_ = CommandMode::POSITION;
+  double stiffness_ = 1.0;
+  bool stiffness_written_ = false;
+
+  // Alias names registered with the DCM.
+  static constexpr const char* kPositionAlias = "naoqi_ros2_control_position";
+  static constexpr const char* kStiffnessAlias = "naoqi_ros2_control_stiffness";
+  static constexpr const char* kVelocityAlias = "naoqi_ros2_control_velocity";
+
+  qi::SessionPtr session_;
+  qi::AnyObject memory_;
+  qi::AnyObject dcm_;
+};
+
+}  // namespace hardware
+}  // namespace naoqi
+
+#endif  // NAOQI_DRIVER_HARDWARE_DCM_SYSTEM_HPP

--- a/include/naoqi_driver/hardware/joint_state_keys.hpp
+++ b/include/naoqi_driver/hardware/joint_state_keys.hpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef NAOQI_DRIVER_HARDWARE_JOINT_STATE_KEYS_HPP
+#define NAOQI_DRIVER_HARDWARE_JOINT_STATE_KEYS_HPP
+
+#include <string>
+#include <vector>
+
+#include <qi/anyobject.hpp>
+
+namespace naoqi
+{
+namespace hardware
+{
+
+/// ALMemory keys for joint state, laid out [positions..., velocities...,
+/// torques...] over the given joints:
+///   Device/SubDeviceList/<Joint>/Position/Sensor/Value
+///   Motion/Velocity/Sensor/<Joint>
+///   Motion/Torque/Sensor/<Joint>
+/// These are populated by the running NAOqi on every version, so both the
+/// ALMotion and DCM systems read state the same way (matching the
+/// joint_state converter).
+std::vector<std::string> jointStateKeys(const std::vector<std::string>& joints);
+
+/// Reads the keys (from jointStateKeys) in one batched getListData and fills
+/// the three output vectors, which must already be sized to the joint count.
+/// Returns false (and logs) on a qi error or unexpected reply size.
+bool readJointStates(qi::AnyObject memory,
+                     const std::vector<std::string>& keys,
+                     std::vector<double>& positions,
+                     std::vector<double>& velocities,
+                     std::vector<double>& efforts);
+
+}  // namespace hardware
+}  // namespace naoqi
+
+#endif  // NAOQI_DRIVER_HARDWARE_JOINT_STATE_KEYS_HPP

--- a/include/naoqi_driver/hardware/lola_protocol.hpp
+++ b/include/naoqi_driver/hardware/lola_protocol.hpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef NAOQI_DRIVER_HARDWARE_LOLA_PROTOCOL_HPP
+#define NAOQI_DRIVER_HARDWARE_LOLA_PROTOCOL_HPP
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace naoqi
+{
+namespace hardware
+{
+namespace lola
+{
+
+/// Canonical LoLA joint order (25 joints). NAO's left/right HipYawPitch are
+/// mechanically coupled, so LoLA exposes a single LHipYawPitch. Confirmed
+/// against ros-sports/nao_lola, B-Human and HTWK clients (see ASSUMPTIONS.md).
+const std::vector<std::string>& jointOrder();
+
+/// Encodes a LoLA actuator frame (MessagePack map) carrying Position and
+/// Stiffness, each a 25-float array in jointOrder(). Other actuator groups
+/// (LEDs) are omitted.
+std::vector<uint8_t> encodeActuators(const std::vector<float>& position,
+                                     const std::vector<float>& stiffness);
+
+/// Decodes a LoLA sensor frame (MessagePack map of string -> array) into a map
+/// from field name (Position, Stiffness, Temperature, ...) to its float values.
+/// Non-numeric fields (e.g. RobotConfig strings) are decoded to empty vectors.
+/// Returns false on a malformed buffer.
+bool decodeSensors(const uint8_t* data,
+                   size_t size,
+                   std::map<std::string, std::vector<float>>& out);
+
+}  // namespace lola
+}  // namespace hardware
+}  // namespace naoqi
+
+#endif  // NAOQI_DRIVER_HARDWARE_LOLA_PROTOCOL_HPP

--- a/include/naoqi_driver/hardware/lola_system.hpp
+++ b/include/naoqi_driver/hardware/lola_system.hpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2025 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef NAOQI_DRIVER_HARDWARE_LOLA_SYSTEM_HPP
+#define NAOQI_DRIVER_HARDWARE_LOLA_SYSTEM_HPP
+
+#include <atomic>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "hardware_interface/system_interface.hpp"
+#include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "rclcpp_lifecycle/state.hpp"
+
+namespace naoqi
+{
+namespace hardware
+{
+
+/// ros2_control SystemInterface driving NAO (and, per internal sources, Pepper
+/// 2.9) joints through the LoLA protocol: a local AF_UNIX socket (/tmp/robocup)
+/// speaking MessagePack at ~83 Hz. This bypasses NAOqi and must run on the
+/// robot. Position command + stiffness only.
+///
+/// A background thread owns the socket and runs the LoLA exchange (recv a
+/// sensor frame, send an actuator frame) at LoLA's pace, so the
+/// controller_manager update rate is decoupled from the 12 ms LoLA cycle.
+/// read()/write() just copy from/to thread-shared buffers.
+///
+/// LoLA exposes 25 joints (one LHipYawPitch). URDF joints are mapped onto that
+/// order; RHipYawPitch aliases LHipYawPitch (mechanically coupled).
+class LolaSystem : public hardware_interface::SystemInterface
+{
+  public:
+  ~LolaSystem() override;
+
+  hardware_interface::CallbackReturn on_init(const hardware_interface::HardwareInfo& info) override;
+
+  hardware_interface::CallbackReturn
+  on_configure(const rclcpp_lifecycle::State& previous_state) override;
+
+  hardware_interface::CallbackReturn
+  on_cleanup(const rclcpp_lifecycle::State& previous_state) override;
+
+  std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
+  std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
+
+  hardware_interface::CallbackReturn
+  on_activate(const rclcpp_lifecycle::State& previous_state) override;
+  hardware_interface::CallbackReturn
+  on_deactivate(const rclcpp_lifecycle::State& previous_state) override;
+
+  hardware_interface::return_type read(const rclcpp::Time& time,
+                                       const rclcpp::Duration& period) override;
+  hardware_interface::return_type write(const rclcpp::Time& time,
+                                        const rclcpp::Duration& period) override;
+
+  private:
+  void ioLoop();
+  void stopIo();
+
+  std::vector<std::string> joint_names_;
+  std::vector<int> lola_index_;  // per URDF joint: index into LoLA's 25 arrays
+
+  std::vector<double> positions_;
+  std::vector<double> velocities_;
+  std::vector<double> efforts_;
+  std::vector<double> position_commands_;
+
+  std::string socket_path_ = "/tmp/robocup";
+  double stiffness_ = 1.0;
+  int fd_ = -1;
+
+  std::thread io_thread_;
+  std::atomic<bool> running_{false};
+  std::atomic<bool> io_ok_{true};
+
+  // Shared with ioLoop(). Sized to LoLA's joint count (25).
+  std::mutex mutex_;
+  std::vector<float> sensor_position_;    // latest sensed positions
+  std::vector<float> command_position_;   // positions to send
+  std::vector<float> command_stiffness_;  // stiffness to send
+  bool sensor_received_ = false;
+};
+
+}  // namespace hardware
+}  // namespace naoqi
+
+#endif  // NAOQI_DRIVER_HARDWARE_LOLA_SYSTEM_HPP

--- a/include/naoqi_driver/hardware/session_factory.hpp
+++ b/include/naoqi_driver/hardware/session_factory.hpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef NAOQI_DRIVER_HARDWARE_SESSION_FACTORY_HPP
+#define NAOQI_DRIVER_HARDWARE_SESSION_FACTORY_HPP
+
+#include <string>
+
+#include <qi/session.hpp>
+
+namespace naoqi
+{
+namespace hardware
+{
+
+/// Sentinel value meaning "no password set" (kept identical to the node CLI).
+inline const char* kNoPassword = "no_password";
+
+/// Connection parameters for a NAOqi session, parsed from ros2_control
+/// <hardware><param> entries. A hardware interface runs inside the
+/// controller_manager process, not the naoqi_driver node, so it opens its own
+/// session.
+struct ConnectionOptions
+{
+  /// When true, no robot is contacted: an in-process fake NAOqi is created
+  /// (see naoqi::fake::createFakeNaoqiSession). Used for tests and CI.
+  bool emulation = false;
+  /// Robot model for emulation ("nao", "pepper", "romeo"). Ignored for real
+  /// connections (the model is read from the robot).
+  std::string robot_type = "nao";
+
+  std::string ip = "127.0.0.1";
+  int port = 9559;
+  std::string user = "nao";
+  std::string password = kNoPassword;
+};
+
+/// Creates a connected qi::Session from the given options, or throws
+/// std::runtime_error on failure. For real connections with a password set and
+/// libqi >= 2.9, TLS is enabled and the default port is switched to 9503,
+/// mirroring external_registration.cpp.
+///
+/// Real connections require a process-wide qi runtime. This factory lazily
+/// instantiates a single qi::Application the first time it connects to a real
+/// robot; the emulation path does not need it.
+qi::SessionPtr makeSession(const ConnectionOptions& options);
+
+}  // namespace hardware
+}  // namespace naoqi
+
+#endif  // NAOQI_DRIVER_HARDWARE_SESSION_FACTORY_HPP

--- a/launch/ros2_control.launch.py
+++ b/launch/ros2_control.launch.py
@@ -20,9 +20,6 @@ controller. Works against a real robot or, with emulation_mode:=true, the
 in-process fake NAOqi (no robot needed).
 """
 
-import os
-
-from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
@@ -31,9 +28,10 @@ from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-    pkg_share = get_package_share_directory("naoqi_driver")
-
     args = [
+        DeclareLaunchArgument("robot", default_value="nao",
+                              description="Robot to bring up: 'nao' or 'pepper'. Selects the "
+                                          "ros2_control description and controllers."),
         DeclareLaunchArgument("emulation_mode", default_value="false",
                               description="Run against the in-process fake NAOqi (no robot)."),
         DeclareLaunchArgument("plugin", default_value="naoqi_driver/AlMotionSystem",
@@ -46,11 +44,14 @@ def generate_launch_description():
                               description="Fraction of each joint's max speed (ALMotion)."),
     ]
 
+    robot = LaunchConfiguration("robot")
+
     robot_description = {
         "robot_description": Command([
             FindExecutable(name="xacro"), " ",
             PathJoinSubstitution([
-                FindPackageShare("naoqi_driver"), "share", "ros2_control", "nao.urdf.xacro"]),
+                FindPackageShare("naoqi_driver"), "share", "ros2_control",
+                [robot, ".urdf.xacro"]]),
             " plugin:=", LaunchConfiguration("plugin"),
             " emulation_mode:=", LaunchConfiguration("emulation_mode"),
             " nao_ip:=", LaunchConfiguration("nao_ip"),
@@ -61,7 +62,8 @@ def generate_launch_description():
         ])
     }
 
-    controllers = os.path.join(pkg_share, "config", "nao_controllers.yaml")
+    controllers = PathJoinSubstitution([
+        FindPackageShare("naoqi_driver"), "config", [robot, "_controllers.yaml"]])
 
     # robot_state_publisher publishes /robot_description, which controller_manager
     # consumes on Iron and later. On Humble, controller_manager reads the
@@ -89,7 +91,7 @@ def generate_launch_description():
     spawn_trajectory_controller = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["nao_joint_trajectory_controller", "-c", "/controller_manager"],
+        arguments=[[robot, "_joint_trajectory_controller"], "-c", "/controller_manager"],
     )
 
     return LaunchDescription(args + [

--- a/launch/ros2_control.launch.py
+++ b/launch/ros2_control.launch.py
@@ -1,0 +1,100 @@
+# Copyright 2025 Aldebaran
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bring up ros2_control for a NAOqi robot.
+
+Loads the controller_manager with a NAOqi hardware backend (ALMotion by
+default), then spawns the joint_state_broadcaster and a joint trajectory
+controller. Works against a real robot or, with emulation_mode:=true, the
+in-process fake NAOqi (no robot needed).
+"""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    pkg_share = get_package_share_directory("naoqi_driver")
+
+    args = [
+        DeclareLaunchArgument("emulation_mode", default_value="false",
+                              description="Run against the in-process fake NAOqi (no robot)."),
+        DeclareLaunchArgument("plugin", default_value="naoqi_driver/AlMotionSystem",
+                              description="ros2_control hardware plugin to load."),
+        DeclareLaunchArgument("nao_ip", default_value="127.0.0.1"),
+        DeclareLaunchArgument("nao_port", default_value="9559"),
+        DeclareLaunchArgument("user", default_value="nao"),
+        DeclareLaunchArgument("password", default_value="no_password"),
+        DeclareLaunchArgument("max_velocity", default_value="0.1",
+                              description="Fraction of each joint's max speed (ALMotion)."),
+    ]
+
+    robot_description = {
+        "robot_description": Command([
+            FindExecutable(name="xacro"), " ",
+            PathJoinSubstitution([
+                FindPackageShare("naoqi_driver"), "share", "ros2_control", "nao.urdf.xacro"]),
+            " plugin:=", LaunchConfiguration("plugin"),
+            " emulation_mode:=", LaunchConfiguration("emulation_mode"),
+            " nao_ip:=", LaunchConfiguration("nao_ip"),
+            " nao_port:=", LaunchConfiguration("nao_port"),
+            " user:=", LaunchConfiguration("user"),
+            " password:=", LaunchConfiguration("password"),
+            " max_velocity:=", LaunchConfiguration("max_velocity"),
+        ])
+    }
+
+    controllers = os.path.join(pkg_share, "config", "nao_controllers.yaml")
+
+    # robot_state_publisher publishes /robot_description, which controller_manager
+    # consumes on Iron and later. On Humble, controller_manager reads the
+    # robot_description parameter instead, so it is also passed there.
+    robot_state_publisher = Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        output="screen",
+        parameters=[robot_description],
+    )
+
+    control_node = Node(
+        package="controller_manager",
+        executable="ros2_control_node",
+        output="screen",
+        parameters=[robot_description, controllers],
+    )
+
+    spawn_broadcaster = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=["joint_state_broadcaster", "-c", "/controller_manager"],
+    )
+
+    spawn_trajectory_controller = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=["nao_joint_trajectory_controller", "-c", "/controller_manager"],
+    )
+
+    return LaunchDescription(args + [
+        robot_state_publisher,
+        control_node,
+        spawn_broadcaster,
+        spawn_trajectory_controller,
+    ])

--- a/naoqi_driver_hardware.xml
+++ b/naoqi_driver_hardware.xml
@@ -1,0 +1,11 @@
+<library path="naoqi_driver_hardware">
+  <class name="naoqi_driver/AlMotionSystem"
+         type="naoqi::hardware::AlMotionSystem"
+         base_class_type="hardware_interface::SystemInterface">
+    <description>
+      ros2_control system driving NAO/Pepper joints through NAOqi's high-level
+      ALMotion service over libqi. Universal fallback (NAOqi 2.1 to 2.9),
+      position command only. Required path on Pepper 2.9.
+    </description>
+  </class>
+</library>

--- a/naoqi_driver_hardware.xml
+++ b/naoqi_driver_hardware.xml
@@ -8,4 +8,13 @@
       position command only. Required path on Pepper 2.9.
     </description>
   </class>
+  <class name="naoqi_driver/DcmSystem"
+         type="naoqi::hardware::DcmSystem"
+         base_class_type="hardware_interface::SystemInterface">
+    <description>
+      ros2_control system driving NAO/Pepper joints through NAOqi's DCM over
+      libqi (NAO 2.1 / Pepper 2.5). Position + stiffness; velocity if the
+      per-joint speed key is provided via the velocity_actuator_key parameter.
+    </description>
+  </class>
 </library>

--- a/naoqi_driver_hardware.xml
+++ b/naoqi_driver_hardware.xml
@@ -17,4 +17,14 @@
       per-joint speed key is provided via the velocity_actuator_key parameter.
     </description>
   </class>
+  <class name="naoqi_driver/LolaSystem"
+         type="naoqi::hardware::LolaSystem"
+         base_class_type="hardware_interface::SystemInterface">
+    <description>
+      ros2_control system driving NAO (and, per internal sources, Pepper 2.9)
+      joints through the LoLA protocol over the local /tmp/robocup socket
+      (MessagePack, ~83 Hz). Bypasses NAOqi; must run on the robot. Position +
+      stiffness.
+    </description>
+  </class>
 </library>

--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,18 @@
   <depend>boost</depend>
   <depend>ament_index_cpp</depend>
 
+  <!-- ros2_control hardware interface -->
+  <depend>hardware_interface</depend>
+  <depend>pluginlib</depend>
+  <depend>rclcpp_lifecycle</depend>
+
+  <!-- ros2_control runtime: controller_manager, controllers, xacro for bringup -->
+  <exec_depend>controller_manager</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
+  <exec_depend>joint_trajectory_controller</exec_depend>
+  <exec_depend>position_controllers</exec_depend>
+  <exec_depend>xacro</exec_depend>
+
   <build_depend>diagnostic_msgs</build_depend>
   <build_depend>diagnostic_updater</build_depend>
   <build_depend>geometry_msgs</build_depend>

--- a/share/ros2_control/nao.urdf.xacro
+++ b/share/ros2_control/nao.urdf.xacro
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<!--
+  Self-contained ros2_control description for NAO, usable without nao_description
+  or meshes. It carries a single base_link plus the <ros2_control> block, which
+  is all controller_manager needs to load a NAOqi hardware backend.
+
+  For visualization (TF/RViz), load a full kinematic NAO URDF separately into
+  robot_state_publisher; the joint names here match the standard NAO joints.
+-->
+<robot name="nao" xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <xacro:arg name="plugin" default="naoqi_driver/AlMotionSystem"/>
+  <xacro:arg name="emulation_mode" default="false"/>
+  <xacro:arg name="nao_ip" default="127.0.0.1"/>
+  <xacro:arg name="nao_port" default="9559"/>
+  <xacro:arg name="user" default="nao"/>
+  <xacro:arg name="password" default="no_password"/>
+  <xacro:arg name="max_velocity" default="0.1"/>
+
+  <xacro:include filename="$(find naoqi_driver)/share/ros2_control/naoqi_system.ros2_control.xacro"/>
+
+  <link name="base_link"/>
+
+  <!-- Standard NAO V6 joints (matches the driver's joint_state converter). -->
+  <xacro:property name="nao_joints" value="${[
+    'HeadYaw', 'HeadPitch',
+    'LShoulderPitch', 'LShoulderRoll', 'LElbowYaw', 'LElbowRoll', 'LWristYaw', 'LHand',
+    'RShoulderPitch', 'RShoulderRoll', 'RElbowYaw', 'RElbowRoll', 'RWristYaw', 'RHand',
+    'LHipYawPitch', 'LHipRoll', 'LHipPitch', 'LKneePitch', 'LAnklePitch', 'LAnkleRoll',
+    'RHipYawPitch', 'RHipRoll', 'RHipPitch', 'RKneePitch', 'RAnklePitch', 'RAnkleRoll']}"/>
+
+  <xacro:naoqi_system
+      name="NaoSystem"
+      plugin="$(arg plugin)"
+      joints="${nao_joints}"
+      robot_type="nao"
+      emulation_mode="$(arg emulation_mode)"
+      nao_ip="$(arg nao_ip)"
+      nao_port="$(arg nao_port)"
+      user="$(arg user)"
+      password="$(arg password)"
+      max_velocity="$(arg max_velocity)"/>
+
+</robot>

--- a/share/ros2_control/naoqi_system.ros2_control.xacro
+++ b/share/ros2_control/naoqi_system.ros2_control.xacro
@@ -38,7 +38,7 @@
               nao_ip:=127.0.0.1 nao_port:=9559
               user:=nao password:=no_password
               max_velocity:=0.1 stiffness:=1.0
-              velocity_actuator_key:=''">
+              velocity_actuator_key:='' lola_socket:=/tmp/robocup">
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>${plugin}</plugin>
@@ -54,6 +54,8 @@
              speed actuator key template, with {} replaced by the joint name. -->
         <param name="stiffness">${stiffness}</param>
         <param name="velocity_actuator_key">${velocity_actuator_key}</param>
+        <!-- LoLA only: path to the local LoLA socket. -->
+        <param name="lola_socket">${lola_socket}</param>
       </hardware>
       <xacro:naoqi_joints joints="${joints}"/>
     </ros2_control>

--- a/share/ros2_control/naoqi_system.ros2_control.xacro
+++ b/share/ros2_control/naoqi_system.ros2_control.xacro
@@ -37,7 +37,8 @@
               emulation_mode:=false robot_type:=nao
               nao_ip:=127.0.0.1 nao_port:=9559
               user:=nao password:=no_password
-              max_velocity:=0.1">
+              max_velocity:=0.1 stiffness:=1.0
+              velocity_actuator_key:=''">
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>${plugin}</plugin>
@@ -47,7 +48,12 @@
         <param name="nao_port">${nao_port}</param>
         <param name="user">${user}</param>
         <param name="password">${password}</param>
+        <!-- ALMotion only: fraction of max joint speed for setAngles. -->
         <param name="max_velocity">${max_velocity}</param>
+        <!-- DCM only: joint stiffness, and (for velocity command) the per-joint
+             speed actuator key template, with {} replaced by the joint name. -->
+        <param name="stiffness">${stiffness}</param>
+        <param name="velocity_actuator_key">${velocity_actuator_key}</param>
       </hardware>
       <xacro:naoqi_joints joints="${joints}"/>
     </ros2_control>

--- a/share/ros2_control/naoqi_system.ros2_control.xacro
+++ b/share/ros2_control/naoqi_system.ros2_control.xacro
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<!--
+  Reusable ros2_control description for NAOqi robots.
+
+  Include this file and call the `naoqi_system` macro from a robot URDF/xacro,
+  passing the list of joints to control and the hardware plugin to use:
+
+    naoqi_driver/AlMotionSystem  - universal, position only (NAOqi 2.1-2.9)
+    naoqi_driver/DcmSystem       - NAO 2.1 / Pepper 2.5, position + velocity (planned)
+    naoqi_driver/LolaSystem      - NAO 2.8+ / Pepper 2.9, position (planned)
+
+  The same connection parameters are accepted by every backend; each ignores the
+  ones it does not need (e.g. LolaSystem ignores nao_ip and connects to the local
+  /tmp/robocup socket).
+-->
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <!-- Emit <joint> entries with a position command and position/velocity/effort
+       state, one per name in the `joints` list. Recursive because xacro has no
+       loop construct. -->
+  <xacro:macro name="naoqi_joints" params="joints">
+    <xacro:if value="${joints}">
+      <xacro:property name="head" value="${joints[0]}"/>
+      <xacro:property name="tail" value="${joints[1:]}"/>
+      <joint name="${head}">
+        <command_interface name="position"/>
+        <state_interface name="position"/>
+        <state_interface name="velocity"/>
+        <state_interface name="effort"/>
+      </joint>
+      <xacro:naoqi_joints joints="${tail}"/>
+    </xacro:if>
+  </xacro:macro>
+
+  <xacro:macro name="naoqi_system"
+      params="name plugin joints
+              emulation_mode:=false robot_type:=nao
+              nao_ip:=127.0.0.1 nao_port:=9559
+              user:=nao password:=no_password
+              max_velocity:=0.1">
+    <ros2_control name="${name}" type="system">
+      <hardware>
+        <plugin>${plugin}</plugin>
+        <param name="emulation_mode">${emulation_mode}</param>
+        <param name="robot_type">${robot_type}</param>
+        <param name="nao_ip">${nao_ip}</param>
+        <param name="nao_port">${nao_port}</param>
+        <param name="user">${user}</param>
+        <param name="password">${password}</param>
+        <param name="max_velocity">${max_velocity}</param>
+      </hardware>
+      <xacro:naoqi_joints joints="${joints}"/>
+    </ros2_control>
+  </xacro:macro>
+
+</robot>

--- a/share/ros2_control/pepper.urdf.xacro
+++ b/share/ros2_control/pepper.urdf.xacro
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<!--
+  Self-contained ros2_control description for Pepper, usable without
+  pepper_description or meshes. It carries a single base_link plus the
+  <ros2_control> block, which is all controller_manager needs to load a NAOqi
+  hardware backend.
+
+  Scope: the 17 articular joints (head, arms, hip, knee). Pepper's holonomic
+  base (WheelFL/WheelFR/WheelB) is velocity-controlled and is handled by the
+  driver's /cmd_vel subscriber (ALMotion.move), not exposed here as joints.
+
+  Backend: AlMotionSystem by default, which works on Pepper 2.5 and 2.9. DCM
+  (Pepper 2.5) and LoLA (Pepper 2.9, hidden) are selectable via the plugin arg;
+  both are assumptions to verify on hardware (see ASSUMPTIONS.md).
+-->
+<robot name="pepper" xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <xacro:arg name="plugin" default="naoqi_driver/AlMotionSystem"/>
+  <xacro:arg name="emulation_mode" default="false"/>
+  <xacro:arg name="nao_ip" default="127.0.0.1"/>
+  <xacro:arg name="nao_port" default="9559"/>
+  <xacro:arg name="user" default="nao"/>
+  <xacro:arg name="password" default="no_password"/>
+  <xacro:arg name="max_velocity" default="0.1"/>
+
+  <xacro:include filename="$(find naoqi_driver)/share/ros2_control/naoqi_system.ros2_control.xacro"/>
+
+  <link name="base_link"/>
+
+  <!-- Pepper articular joints (matches the driver's joint_state converter). -->
+  <xacro:property name="pepper_joints" value="${[
+    'HeadYaw', 'HeadPitch',
+    'LShoulderPitch', 'LShoulderRoll', 'LElbowYaw', 'LElbowRoll', 'LWristYaw', 'LHand',
+    'RShoulderPitch', 'RShoulderRoll', 'RElbowYaw', 'RElbowRoll', 'RWristYaw', 'RHand',
+    'HipRoll', 'HipPitch', 'KneePitch']}"/>
+
+  <xacro:naoqi_system
+      name="PepperSystem"
+      plugin="$(arg plugin)"
+      joints="${pepper_joints}"
+      robot_type="pepper"
+      emulation_mode="$(arg emulation_mode)"
+      nao_ip="$(arg nao_ip)"
+      nao_port="$(arg nao_port)"
+      user="$(arg user)"
+      password="$(arg password)"
+      max_velocity="$(arg max_velocity)"/>
+
+</robot>

--- a/src/fake_naoqi/fake_dcm.cpp
+++ b/src/fake_naoqi/fake_dcm.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2025 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "fake_dcm.hpp"
+
+#include <chrono>
+#include <iostream>
+
+#include <qi/type/dynamicobjectbuilder.hpp>
+
+namespace naoqi
+{
+namespace fake
+{
+
+FakeDCM::FakeDCM(qi::AnyObject memory) : memory_(memory) {}
+
+int FakeDCM::getTime(int delay)
+{
+  using namespace std::chrono;
+  const auto now = duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count();
+  return static_cast<int>(now) + delay;
+}
+
+void FakeDCM::createAlias(const qi::AnyValue& alias)
+{
+  const auto items = alias.to<std::vector<qi::AnyValue>>();
+  if (items.size() < 2)
+  {
+    std::cerr << "FakeDCM::createAlias: expected [name, [keys]]" << std::endl;
+    return;
+  }
+  const auto name = items[0].to<std::string>();
+  const auto keys = items[1].to<std::vector<std::string>>();
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  aliases_[name] = keys;
+}
+
+void FakeDCM::setAlias(const qi::AnyValue& command)
+{
+  const auto items = command.to<std::vector<qi::AnyValue>>();
+  if (items.size() < 6)
+  {
+    std::cerr << "FakeDCM::setAlias: expected a 6-element command" << std::endl;
+    return;
+  }
+  const auto name = items[0].to<std::string>();
+  // [5] is a list of per-actuator value lists; take the last timed value of each.
+  const auto values = items[5].to<std::vector<std::vector<float>>>();
+
+  std::vector<std::string> keys;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto it = aliases_.find(name);
+    if (it == aliases_.end())
+    {
+      std::cerr << "FakeDCM::setAlias: unknown alias '" << name << "'" << std::endl;
+      return;
+    }
+    keys = it->second;
+  }
+
+  if (values.size() != keys.size())
+  {
+    std::cerr << "FakeDCM::setAlias: " << values.size() << " values for " << keys.size() << " keys"
+              << std::endl;
+    return;
+  }
+
+  for (size_t i = 0; i < keys.size(); ++i)
+  {
+    if (values[i].empty())
+      continue;
+    const float value = values[i].back();
+    memory_.call<void>("insertData", keys[i], qi::AnyValue::from(value));
+
+    // Close the loop: a commanded ".../Actuator/Value" becomes the matching
+    // ".../Sensor/Value" the state read path consumes.
+    const std::string& key = keys[i];
+    const auto pos = key.find("/Actuator/");
+    if (pos != std::string::npos)
+    {
+      std::string sensor_key = key;
+      sensor_key.replace(pos, std::string("/Actuator/").size(), "/Sensor/");
+      memory_.call<void>("insertData", sensor_key, qi::AnyValue::from(value));
+    }
+  }
+}
+
+}  // namespace fake
+}  // namespace naoqi
+
+QI_REGISTER_OBJECT(naoqi::fake::FakeDCM, getTime, createAlias, setAlias)

--- a/src/fake_naoqi/fake_dcm.hpp
+++ b/src/fake_naoqi/fake_dcm.hpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef FAKE_DCM_HPP
+#define FAKE_DCM_HPP
+
+#include <map>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <qi/anyobject.hpp>
+#include <qi/anyvalue.hpp>
+
+namespace naoqi
+{
+namespace fake
+{
+
+/// Fake NAOqi DCM service, just enough to exercise the DCM ros2_control system
+/// in emulation. Implements the createAlias/getTime/setAlias flow used to write
+/// actuator values, and closes the control loop by mirroring each
+/// ".../Actuator/Value" it receives to the matching ".../Sensor/Value" in
+/// ALMemory, so a commanded position is read back as the sensed position.
+class FakeDCM
+{
+  public:
+  explicit FakeDCM(qi::AnyObject memory);
+
+  /// Current DCM time in ms, plus an optional future delay.
+  int getTime(int delay);
+
+  /// alias = [name, [memory_key, ...]].
+  void createAlias(const qi::AnyValue& alias);
+
+  /// command = [name, updateType, "time-separate", 0, [times], [[v0],[v1],...]].
+  /// Only the alias name and the per-actuator values are used here.
+  void setAlias(const qi::AnyValue& command);
+
+  private:
+  qi::AnyObject memory_;
+  std::map<std::string, std::vector<std::string>> aliases_;
+  std::mutex mutex_;
+};
+
+}  // namespace fake
+}  // namespace naoqi
+
+#endif  // FAKE_DCM_HPP

--- a/src/fake_naoqi/fake_naoqi.cpp
+++ b/src/fake_naoqi/fake_naoqi.cpp
@@ -18,6 +18,7 @@
 #include "fake_naoqi.hpp"
 #include "fake_almemory.hpp"
 #include "fake_almotion.hpp"
+#include "fake_dcm.hpp"
 #include "fake_services.hpp"
 
 #include <iostream>
@@ -45,6 +46,7 @@ qi::SessionPtr createFakeNaoqiSession(const std::string& robot_type)
   // QI_REGISTER_OBJECT allows these to be registered as services
   auto memory = boost::make_shared<FakeALMemory>(robot_type);
   auto motion = boost::make_shared<FakeALMotion>(robot_type, qi::AnyObject(memory));
+  auto dcm = boost::make_shared<FakeDCM>(qi::AnyObject(memory));
   auto tts = boost::make_shared<FakeALTextToSpeech>();
   auto video = boost::make_shared<FakeALVideoDevice>();
   auto audio = boost::make_shared<FakeALAudioDevice>();
@@ -61,6 +63,7 @@ qi::SessionPtr createFakeNaoqiSession(const std::string& robot_type)
   {
     session->registerService("ALMotion", motion);
     session->registerService("ALMemory", memory);
+    session->registerService("DCM", dcm);
     session->registerService("ALTextToSpeech", tts);
     session->registerService("ALVideoDevice", video);
     session->registerService("ALAudioDevice", audio);

--- a/src/hardware/almotion_system.cpp
+++ b/src/hardware/almotion_system.cpp
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2025 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "naoqi_driver/hardware/almotion_system.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <string>
+#include <unordered_map>
+
+#include <qi/anyvalue.hpp>
+
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "naoqi_driver/hardware/session_factory.hpp"
+#include "pluginlib/class_list_macros.hpp"
+#include "rclcpp/logging.hpp"
+
+namespace naoqi
+{
+namespace hardware
+{
+
+namespace
+{
+rclcpp::Logger logger()
+{
+  return rclcpp::get_logger("AlMotionSystem");
+}
+
+std::string getParam(const std::unordered_map<std::string, std::string>& params,
+                     const std::string& key,
+                     const std::string& fallback)
+{
+  const auto it = params.find(key);
+  return it != params.end() ? it->second : fallback;
+}
+
+double toDouble(const qi::AnyValue& value)
+{
+  // Some joints (e.g. hands) have no velocity or torque key; ALMemory returns
+  // a void there. Treat it as zero, like the joint_state converter.
+  if (value.kind() == qi::TypeKind_Void)
+  {
+    return 0.0;
+  }
+  return value.toDouble();
+}
+}  // namespace
+
+hardware_interface::CallbackReturn
+AlMotionSystem::on_init(const hardware_interface::HardwareInfo& info)
+{
+  if (SystemInterface::on_init(info) != hardware_interface::CallbackReturn::SUCCESS)
+  {
+    return hardware_interface::CallbackReturn::ERROR;
+  }
+
+  max_velocity_fraction_ = std::stod(getParam(info_.hardware_parameters, "max_velocity", "0.1"));
+  if (max_velocity_fraction_ <= 0.0 || max_velocity_fraction_ > 1.0)
+  {
+    RCLCPP_ERROR(logger(), "max_velocity must be in (0, 1], got %f", max_velocity_fraction_);
+    return hardware_interface::CallbackReturn::ERROR;
+  }
+
+  joint_names_.reserve(info_.joints.size());
+  for (const auto& joint : info_.joints)
+  {
+    // ALMotion commands position only.
+    if (joint.command_interfaces.size() != 1 ||
+        joint.command_interfaces[0].name != hardware_interface::HW_IF_POSITION)
+    {
+      RCLCPP_ERROR(logger(),
+                   "Joint '%s' must expose exactly one command interface '%s'.",
+                   joint.name.c_str(),
+                   hardware_interface::HW_IF_POSITION);
+      return hardware_interface::CallbackReturn::ERROR;
+    }
+    joint_names_.push_back(joint.name);
+  }
+
+  const size_t n = joint_names_.size();
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  positions_.assign(n, nan);
+  velocities_.assign(n, 0.0);
+  efforts_.assign(n, 0.0);
+  position_commands_.assign(n, nan);
+
+  // Layout [positions..., velocities..., torques...], matching read().
+  memory_keys_.clear();
+  memory_keys_.reserve(3 * n);
+  for (const auto& name : joint_names_)
+    memory_keys_.push_back("Device/SubDeviceList/" + name + "/Position/Sensor/Value");
+  for (const auto& name : joint_names_)
+    memory_keys_.push_back("Motion/Velocity/Sensor/" + name);
+  for (const auto& name : joint_names_)
+    memory_keys_.push_back("Motion/Torque/Sensor/" + name);
+
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn
+AlMotionSystem::on_configure(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  ConnectionOptions options;
+  const auto& p = info_.hardware_parameters;
+  options.emulation = getParam(p, "emulation_mode", "false") == "true";
+  options.robot_type = getParam(p, "robot_type", "nao");
+  options.ip = getParam(p, "nao_ip", "127.0.0.1");
+  options.port = std::stoi(getParam(p, "nao_port", "9559"));
+  options.user = getParam(p, "user", "nao");
+  options.password = getParam(p, "password", kNoPassword);
+
+  try
+  {
+    session_ = makeSession(options);
+    motion_ = session_->service("ALMotion").value();
+    memory_ = session_->service("ALMemory").value();
+  }
+  catch (const std::exception& e)
+  {
+    RCLCPP_ERROR(logger(), "Failed to configure ALMotion system: %s", e.what());
+    return hardware_interface::CallbackReturn::ERROR;
+  }
+
+  RCLCPP_INFO(logger(),
+              "Connected to ALMotion (%zu joints, %s mode).",
+              joint_names_.size(),
+              options.emulation ? "emulation" : "robot");
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn
+AlMotionSystem::on_cleanup(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  motion_ = qi::AnyObject();
+  memory_ = qi::AnyObject();
+  if (session_)
+  {
+    session_->close();
+    session_.reset();
+  }
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+std::vector<hardware_interface::StateInterface> AlMotionSystem::export_state_interfaces()
+{
+  std::vector<hardware_interface::StateInterface> interfaces;
+  for (size_t i = 0; i < joint_names_.size(); ++i)
+  {
+    interfaces.emplace_back(joint_names_[i], hardware_interface::HW_IF_POSITION, &positions_[i]);
+    interfaces.emplace_back(joint_names_[i], hardware_interface::HW_IF_VELOCITY, &velocities_[i]);
+    interfaces.emplace_back(joint_names_[i], hardware_interface::HW_IF_EFFORT, &efforts_[i]);
+  }
+  return interfaces;
+}
+
+std::vector<hardware_interface::CommandInterface> AlMotionSystem::export_command_interfaces()
+{
+  std::vector<hardware_interface::CommandInterface> interfaces;
+  for (size_t i = 0; i < joint_names_.size(); ++i)
+  {
+    interfaces.emplace_back(
+        joint_names_[i], hardware_interface::HW_IF_POSITION, &position_commands_[i]);
+  }
+  return interfaces;
+}
+
+hardware_interface::CallbackReturn
+AlMotionSystem::on_activate(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  // Seed the command with the current state so controllers do not jerk the
+  // robot to an uninitialized target on the first write().
+  if (read(rclcpp::Time(0), rclcpp::Duration(0, 0)) != hardware_interface::return_type::OK)
+  {
+    return hardware_interface::CallbackReturn::ERROR;
+  }
+  position_commands_ = positions_;
+
+  // Stiffen the joints so commands take effect. Optional: the fake ALMotion
+  // does not implement setStiffnesses, and some setups manage stiffness
+  // elsewhere, so a failure here is only a warning.
+  try
+  {
+    motion_.call<void>("setStiffnesses", std::string("Body"), 1.0f);
+  }
+  catch (const std::exception& e)
+  {
+    RCLCPP_WARN(logger(), "Could not set stiffness on activation: %s", e.what());
+  }
+
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn
+AlMotionSystem::on_deactivate(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::return_type AlMotionSystem::read(const rclcpp::Time& /*time*/,
+                                                     const rclcpp::Duration& /*period*/)
+{
+  const size_t n = joint_names_.size();
+  std::vector<qi::AnyValue> data;
+  try
+  {
+    data = memory_.call<std::vector<qi::AnyValue>>("getListData", memory_keys_);
+  }
+  catch (const std::exception& e)
+  {
+    RCLCPP_ERROR(logger(), "ALMemory read failed: %s", e.what());
+    return hardware_interface::return_type::ERROR;
+  }
+
+  if (data.size() != 3 * n)
+  {
+    RCLCPP_ERROR(logger(), "ALMemory returned %zu values, expected %zu.", data.size(), 3 * n);
+    return hardware_interface::return_type::ERROR;
+  }
+
+  for (size_t i = 0; i < n; ++i)
+  {
+    positions_[i] = toDouble(data[i]);
+    velocities_[i] = toDouble(data[n + i]);
+    efforts_[i] = toDouble(data[2 * n + i]);
+  }
+  return hardware_interface::return_type::OK;
+}
+
+hardware_interface::return_type AlMotionSystem::write(const rclcpp::Time& /*time*/,
+                                                      const rclcpp::Duration& /*period*/)
+{
+  std::vector<float> angles(joint_names_.size());
+  for (size_t i = 0; i < joint_names_.size(); ++i)
+  {
+    if (std::isnan(position_commands_[i]))
+    {
+      // No controller has written a command yet; do not move.
+      return hardware_interface::return_type::OK;
+    }
+    angles[i] = static_cast<float>(position_commands_[i]);
+  }
+
+  try
+  {
+    motion_.call<void>(
+        "setAngles", joint_names_, angles, static_cast<float>(max_velocity_fraction_));
+  }
+  catch (const std::exception& e)
+  {
+    RCLCPP_ERROR(logger(), "ALMotion setAngles failed: %s", e.what());
+    return hardware_interface::return_type::ERROR;
+  }
+  return hardware_interface::return_type::OK;
+}
+
+}  // namespace hardware
+}  // namespace naoqi
+
+PLUGINLIB_EXPORT_CLASS(naoqi::hardware::AlMotionSystem, hardware_interface::SystemInterface)

--- a/src/hardware/almotion_system.cpp
+++ b/src/hardware/almotion_system.cpp
@@ -26,6 +26,7 @@
 #include <qi/anyvalue.hpp>
 
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "naoqi_driver/hardware/joint_state_keys.hpp"
 #include "naoqi_driver/hardware/session_factory.hpp"
 #include "pluginlib/class_list_macros.hpp"
 #include "rclcpp/logging.hpp"
@@ -48,17 +49,6 @@ std::string getParam(const std::unordered_map<std::string, std::string>& params,
 {
   const auto it = params.find(key);
   return it != params.end() ? it->second : fallback;
-}
-
-double toDouble(const qi::AnyValue& value)
-{
-  // Some joints (e.g. hands) have no velocity or torque key; ALMemory returns
-  // a void there. Treat it as zero, like the joint_state converter.
-  if (value.kind() == qi::TypeKind_Void)
-  {
-    return 0.0;
-  }
-  return value.toDouble();
 }
 }  // namespace
 
@@ -100,15 +90,7 @@ AlMotionSystem::on_init(const hardware_interface::HardwareInfo& info)
   efforts_.assign(n, 0.0);
   position_commands_.assign(n, nan);
 
-  // Layout [positions..., velocities..., torques...], matching read().
-  memory_keys_.clear();
-  memory_keys_.reserve(3 * n);
-  for (const auto& name : joint_names_)
-    memory_keys_.push_back("Device/SubDeviceList/" + name + "/Position/Sensor/Value");
-  for (const auto& name : joint_names_)
-    memory_keys_.push_back("Motion/Velocity/Sensor/" + name);
-  for (const auto& name : joint_names_)
-    memory_keys_.push_back("Motion/Torque/Sensor/" + name);
+  memory_keys_ = jointStateKeys(joint_names_);
 
   return hardware_interface::CallbackReturn::SUCCESS;
 }
@@ -215,30 +197,8 @@ AlMotionSystem::on_deactivate(const rclcpp_lifecycle::State& /*previous_state*/)
 hardware_interface::return_type AlMotionSystem::read(const rclcpp::Time& /*time*/,
                                                      const rclcpp::Duration& /*period*/)
 {
-  const size_t n = joint_names_.size();
-  std::vector<qi::AnyValue> data;
-  try
-  {
-    data = memory_.call<std::vector<qi::AnyValue>>("getListData", memory_keys_);
-  }
-  catch (const std::exception& e)
-  {
-    RCLCPP_ERROR(logger(), "ALMemory read failed: %s", e.what());
+  if (!readJointStates(memory_, memory_keys_, positions_, velocities_, efforts_))
     return hardware_interface::return_type::ERROR;
-  }
-
-  if (data.size() != 3 * n)
-  {
-    RCLCPP_ERROR(logger(), "ALMemory returned %zu values, expected %zu.", data.size(), 3 * n);
-    return hardware_interface::return_type::ERROR;
-  }
-
-  for (size_t i = 0; i < n; ++i)
-  {
-    positions_[i] = toDouble(data[i]);
-    velocities_[i] = toDouble(data[n + i]);
-    efforts_[i] = toDouble(data[2 * n + i]);
-  }
   return hardware_interface::return_type::OK;
 }
 

--- a/src/hardware/dcm_system.cpp
+++ b/src/hardware/dcm_system.cpp
@@ -1,0 +1,317 @@
+/*
+ * Copyright 2025 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "naoqi_driver/hardware/dcm_system.hpp"
+
+#include <cmath>
+#include <limits>
+#include <string>
+#include <unordered_map>
+
+#include <qi/anyvalue.hpp>
+
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "naoqi_driver/hardware/joint_state_keys.hpp"
+#include "naoqi_driver/hardware/session_factory.hpp"
+#include "pluginlib/class_list_macros.hpp"
+#include "rclcpp/logging.hpp"
+
+namespace naoqi
+{
+namespace hardware
+{
+
+namespace
+{
+rclcpp::Logger logger()
+{
+  return rclcpp::get_logger("DcmSystem");
+}
+
+std::string getParam(const std::unordered_map<std::string, std::string>& params,
+                     const std::string& key,
+                     const std::string& fallback)
+{
+  const auto it = params.find(key);
+  return it != params.end() ? it->second : fallback;
+}
+
+/// Substitutes the joint name into a key template, replacing the first "{}".
+std::string fillTemplate(const std::string& tmpl, const std::string& joint)
+{
+  const auto pos = tmpl.find("{}");
+  if (pos == std::string::npos)
+    return tmpl;
+  std::string out = tmpl;
+  out.replace(pos, 2, joint);
+  return out;
+}
+}  // namespace
+
+hardware_interface::CallbackReturn DcmSystem::on_init(const hardware_interface::HardwareInfo& info)
+{
+  if (SystemInterface::on_init(info) != hardware_interface::CallbackReturn::SUCCESS)
+    return hardware_interface::CallbackReturn::ERROR;
+
+  stiffness_ = std::stod(getParam(info_.hardware_parameters, "stiffness", "1.0"));
+  const std::string velocity_key_tmpl =
+      getParam(info_.hardware_parameters, "velocity_actuator_key", "");
+
+  // Determine the command mode from the URDF: every joint must declare exactly
+  // one command interface, and they must all be the same ("position" or
+  // "velocity"). Mixing modes would need command-mode switching, which the DCM
+  // system does not implement yet.
+  bool mode_set = false;
+  for (const auto& joint : info_.joints)
+  {
+    if (joint.command_interfaces.size() != 1)
+    {
+      RCLCPP_ERROR(logger(),
+                   "Joint '%s' must declare exactly one command interface (position or velocity).",
+                   joint.name.c_str());
+      return hardware_interface::CallbackReturn::ERROR;
+    }
+    const std::string& cmd = joint.command_interfaces[0].name;
+    CommandMode mode;
+    if (cmd == hardware_interface::HW_IF_POSITION)
+      mode = CommandMode::POSITION;
+    else if (cmd == hardware_interface::HW_IF_VELOCITY)
+      mode = CommandMode::VELOCITY;
+    else
+    {
+      RCLCPP_ERROR(logger(),
+                   "Joint '%s' has unsupported command interface '%s'.",
+                   joint.name.c_str(),
+                   cmd.c_str());
+      return hardware_interface::CallbackReturn::ERROR;
+    }
+    if (mode_set && mode != command_mode_)
+    {
+      RCLCPP_ERROR(logger(),
+                   "All joints must share the same command interface (position XOR "
+                   "velocity); joint '%s' differs.",
+                   joint.name.c_str());
+      return hardware_interface::CallbackReturn::ERROR;
+    }
+    command_mode_ = mode;
+    mode_set = true;
+    joint_names_.push_back(joint.name);
+  }
+
+  if (command_mode_ == CommandMode::VELOCITY && velocity_key_tmpl.empty())
+  {
+    RCLCPP_ERROR(logger(),
+                 "Velocity command requested but 'velocity_actuator_key' is not set. The "
+                 "per-joint DCM speed key must be provided (see ASSUMPTIONS.md).");
+    return hardware_interface::CallbackReturn::ERROR;
+  }
+
+  const size_t n = joint_names_.size();
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  positions_.assign(n, nan);
+  velocities_.assign(n, 0.0);
+  efforts_.assign(n, 0.0);
+  commands_.assign(n, nan);
+
+  memory_keys_ = jointStateKeys(joint_names_);
+  for (const auto& name : joint_names_)
+  {
+    position_keys_.push_back("Device/SubDeviceList/" + name + "/Position/Actuator/Value");
+    stiffness_keys_.push_back("Device/SubDeviceList/" + name + "/Hardness/Actuator/Value");
+    if (command_mode_ == CommandMode::VELOCITY)
+      velocity_keys_.push_back(fillTemplate(velocity_key_tmpl, name));
+  }
+
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn
+DcmSystem::on_configure(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  ConnectionOptions options;
+  const auto& p = info_.hardware_parameters;
+  options.emulation = getParam(p, "emulation_mode", "false") == "true";
+  options.robot_type = getParam(p, "robot_type", "nao");
+  options.ip = getParam(p, "nao_ip", "127.0.0.1");
+  options.port = std::stoi(getParam(p, "nao_port", "9559"));
+  options.user = getParam(p, "user", "nao");
+  options.password = getParam(p, "password", kNoPassword);
+
+  try
+  {
+    session_ = makeSession(options);
+    memory_ = session_->service("ALMemory").value();
+    dcm_ = session_->service("DCM").value();
+
+    createAlias(kStiffnessAlias, stiffness_keys_);
+    if (command_mode_ == CommandMode::POSITION)
+      createAlias(kPositionAlias, position_keys_);
+    else
+      createAlias(kVelocityAlias, velocity_keys_);
+  }
+  catch (const std::exception& e)
+  {
+    RCLCPP_ERROR(logger(), "Failed to configure DCM system: %s", e.what());
+    return hardware_interface::CallbackReturn::ERROR;
+  }
+
+  RCLCPP_INFO(logger(),
+              "Connected to DCM (%zu joints, %s command, %s mode).",
+              joint_names_.size(),
+              command_mode_ == CommandMode::POSITION ? "position" : "velocity",
+              options.emulation ? "emulation" : "robot");
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn
+DcmSystem::on_cleanup(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  dcm_ = qi::AnyObject();
+  memory_ = qi::AnyObject();
+  if (session_)
+  {
+    session_->close();
+    session_.reset();
+  }
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+std::vector<hardware_interface::StateInterface> DcmSystem::export_state_interfaces()
+{
+  std::vector<hardware_interface::StateInterface> interfaces;
+  for (size_t i = 0; i < joint_names_.size(); ++i)
+  {
+    interfaces.emplace_back(joint_names_[i], hardware_interface::HW_IF_POSITION, &positions_[i]);
+    interfaces.emplace_back(joint_names_[i], hardware_interface::HW_IF_VELOCITY, &velocities_[i]);
+    interfaces.emplace_back(joint_names_[i], hardware_interface::HW_IF_EFFORT, &efforts_[i]);
+  }
+  return interfaces;
+}
+
+std::vector<hardware_interface::CommandInterface> DcmSystem::export_command_interfaces()
+{
+  const char* interface = command_mode_ == CommandMode::POSITION
+                              ? hardware_interface::HW_IF_POSITION
+                              : hardware_interface::HW_IF_VELOCITY;
+  std::vector<hardware_interface::CommandInterface> interfaces;
+  for (size_t i = 0; i < joint_names_.size(); ++i)
+    interfaces.emplace_back(joint_names_[i], interface, &commands_[i]);
+  return interfaces;
+}
+
+hardware_interface::CallbackReturn
+DcmSystem::on_activate(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  if (read(rclcpp::Time(0), rclcpp::Duration(0, 0)) != hardware_interface::return_type::OK)
+    return hardware_interface::CallbackReturn::ERROR;
+
+  // Seed the command so the first write() holds position / commands zero velocity.
+  if (command_mode_ == CommandMode::POSITION)
+    commands_ = positions_;
+  else
+    commands_.assign(joint_names_.size(), 0.0);
+
+  try
+  {
+    setAlias(kStiffnessAlias,
+             std::vector<float>(joint_names_.size(), static_cast<float>(stiffness_)));
+    stiffness_written_ = true;
+  }
+  catch (const std::exception& e)
+  {
+    RCLCPP_ERROR(logger(), "Failed to set stiffness via DCM: %s", e.what());
+    return hardware_interface::CallbackReturn::ERROR;
+  }
+
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn
+DcmSystem::on_deactivate(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::return_type DcmSystem::read(const rclcpp::Time& /*time*/,
+                                                const rclcpp::Duration& /*period*/)
+{
+  if (!readJointStates(memory_, memory_keys_, positions_, velocities_, efforts_))
+    return hardware_interface::return_type::ERROR;
+  return hardware_interface::return_type::OK;
+}
+
+hardware_interface::return_type DcmSystem::write(const rclcpp::Time& /*time*/,
+                                                 const rclcpp::Duration& /*period*/)
+{
+  std::vector<float> values(joint_names_.size());
+  for (size_t i = 0; i < joint_names_.size(); ++i)
+  {
+    if (std::isnan(commands_[i]))
+      return hardware_interface::return_type::OK;  // not commanded yet
+    values[i] = static_cast<float>(commands_[i]);
+  }
+
+  try
+  {
+    if (!stiffness_written_)
+    {
+      setAlias(kStiffnessAlias,
+               std::vector<float>(joint_names_.size(), static_cast<float>(stiffness_)));
+      stiffness_written_ = true;
+    }
+    setAlias(command_mode_ == CommandMode::POSITION ? kPositionAlias : kVelocityAlias, values);
+  }
+  catch (const std::exception& e)
+  {
+    RCLCPP_ERROR(logger(), "DCM setAlias failed: %s", e.what());
+    return hardware_interface::return_type::ERROR;
+  }
+  return hardware_interface::return_type::OK;
+}
+
+void DcmSystem::createAlias(const std::string& name, const std::vector<std::string>& keys)
+{
+  std::vector<qi::AnyValue> alias;
+  alias.push_back(qi::AnyValue::from(name));
+  alias.push_back(qi::AnyValue::from(keys));
+  dcm_.call<void>("createAlias", qi::AnyValue::from(alias));
+}
+
+void DcmSystem::setAlias(const std::string& name, const std::vector<float>& values)
+{
+  const int t = dcm_.call<int>("getTime", 0);
+  const std::vector<int> times{t};
+  std::vector<std::vector<float>> timed_values;
+  timed_values.reserve(values.size());
+  for (const float v : values)
+    timed_values.push_back({v});
+
+  // [name, updateType, "time-separate", 0, [times], [[v0],[v1],...]]
+  std::vector<qi::AnyValue> command;
+  command.push_back(qi::AnyValue::from(name));
+  command.push_back(qi::AnyValue::from(std::string("ClearAll")));
+  command.push_back(qi::AnyValue::from(std::string("time-separate")));
+  command.push_back(qi::AnyValue::from(0));
+  command.push_back(qi::AnyValue::from(times));
+  command.push_back(qi::AnyValue::from(timed_values));
+  dcm_.call<void>("setAlias", qi::AnyValue::from(command));
+}
+
+}  // namespace hardware
+}  // namespace naoqi
+
+PLUGINLIB_EXPORT_CLASS(naoqi::hardware::DcmSystem, hardware_interface::SystemInterface)

--- a/src/hardware/joint_state_keys.cpp
+++ b/src/hardware/joint_state_keys.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "naoqi_driver/hardware/joint_state_keys.hpp"
+
+#include <qi/anyvalue.hpp>
+
+#include "rclcpp/logging.hpp"
+
+namespace naoqi
+{
+namespace hardware
+{
+
+namespace
+{
+double toDouble(const qi::AnyValue& value)
+{
+  // Some joints (e.g. hands) have no velocity or torque key; ALMemory returns
+  // a void there. Treat it as zero, like the joint_state converter.
+  if (value.kind() == qi::TypeKind_Void)
+  {
+    return 0.0;
+  }
+  return value.toDouble();
+}
+}  // namespace
+
+std::vector<std::string> jointStateKeys(const std::vector<std::string>& joints)
+{
+  std::vector<std::string> keys;
+  keys.reserve(3 * joints.size());
+  for (const auto& name : joints)
+    keys.push_back("Device/SubDeviceList/" + name + "/Position/Sensor/Value");
+  for (const auto& name : joints)
+    keys.push_back("Motion/Velocity/Sensor/" + name);
+  for (const auto& name : joints)
+    keys.push_back("Motion/Torque/Sensor/" + name);
+  return keys;
+}
+
+bool readJointStates(qi::AnyObject memory,
+                     const std::vector<std::string>& keys,
+                     std::vector<double>& positions,
+                     std::vector<double>& velocities,
+                     std::vector<double>& efforts)
+{
+  const size_t n = positions.size();
+  std::vector<qi::AnyValue> data;
+  try
+  {
+    data = memory.call<std::vector<qi::AnyValue>>("getListData", keys);
+  }
+  catch (const std::exception& e)
+  {
+    RCLCPP_ERROR(rclcpp::get_logger("naoqi_hardware"), "ALMemory read failed: %s", e.what());
+    return false;
+  }
+
+  if (data.size() != 3 * n)
+  {
+    RCLCPP_ERROR(rclcpp::get_logger("naoqi_hardware"),
+                 "ALMemory returned %zu values, expected %zu.",
+                 data.size(),
+                 3 * n);
+    return false;
+  }
+
+  for (size_t i = 0; i < n; ++i)
+  {
+    positions[i] = toDouble(data[i]);
+    velocities[i] = toDouble(data[n + i]);
+    efforts[i] = toDouble(data[2 * n + i]);
+  }
+  return true;
+}
+
+}  // namespace hardware
+}  // namespace naoqi

--- a/src/hardware/lola_protocol.cpp
+++ b/src/hardware/lola_protocol.cpp
@@ -1,0 +1,332 @@
+/*
+ * Copyright 2025 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "naoqi_driver/hardware/lola_protocol.hpp"
+
+#include <cstring>
+
+// Minimal MessagePack codec for the subset LoLA uses: maps of string keys to
+// arrays of float32 (and a few integer / string fields we tolerate but ignore).
+// Hand-rolled to avoid a msgpack system dependency. Wire format follows the
+// MessagePack spec (big-endian). Correctness against real LoLA is to be
+// verified on hardware (see ASSUMPTIONS.md); the fake LoLA server round-trips
+// the same codec in CI.
+
+namespace naoqi
+{
+namespace hardware
+{
+namespace lola
+{
+
+const std::vector<std::string>& jointOrder()
+{
+  static const std::vector<std::string> kJoints = {
+      "HeadYaw",    "HeadPitch",   "LShoulderPitch", "LShoulderRoll",  "LElbowYaw",
+      "LElbowRoll", "LWristYaw",   "LHipYawPitch",   "LHipRoll",       "LHipPitch",
+      "LKneePitch", "LAnklePitch", "LAnkleRoll",     "RHipRoll",       "RHipPitch",
+      "RKneePitch", "RAnklePitch", "RAnkleRoll",     "RShoulderPitch", "RShoulderRoll",
+      "RElbowYaw",  "RElbowRoll",  "RWristYaw",      "LHand",          "RHand"};
+  return kJoints;
+}
+
+namespace
+{
+void writeByte(std::vector<uint8_t>& b, uint8_t v)
+{
+  b.push_back(v);
+}
+
+void writeStr(std::vector<uint8_t>& b, const std::string& s)
+{
+  if (s.size() < 32)
+  {
+    writeByte(b, static_cast<uint8_t>(0xa0 | s.size()));
+  }
+  else
+  {
+    writeByte(b, 0xd9);
+    writeByte(b, static_cast<uint8_t>(s.size()));
+  }
+  b.insert(b.end(), s.begin(), s.end());
+}
+
+void writeArrayHeader(std::vector<uint8_t>& b, size_t n)
+{
+  if (n < 16)
+  {
+    writeByte(b, static_cast<uint8_t>(0x90 | n));
+  }
+  else
+  {
+    writeByte(b, 0xdc);
+    writeByte(b, static_cast<uint8_t>((n >> 8) & 0xff));
+    writeByte(b, static_cast<uint8_t>(n & 0xff));
+  }
+}
+
+void writeFloat32(std::vector<uint8_t>& b, float f)
+{
+  uint32_t u;
+  std::memcpy(&u, &f, 4);
+  writeByte(b, 0xca);
+  writeByte(b, static_cast<uint8_t>((u >> 24) & 0xff));
+  writeByte(b, static_cast<uint8_t>((u >> 16) & 0xff));
+  writeByte(b, static_cast<uint8_t>((u >> 8) & 0xff));
+  writeByte(b, static_cast<uint8_t>(u & 0xff));
+}
+
+void writeFloatArray(std::vector<uint8_t>& b,
+                     const std::string& key,
+                     const std::vector<float>& values)
+{
+  writeStr(b, key);
+  writeArrayHeader(b, values.size());
+  for (float v : values)
+    writeFloat32(b, v);
+}
+
+/// Cursor over a byte buffer with bounds-checked reads.
+struct Reader
+{
+  const uint8_t* p;
+  const uint8_t* end;
+
+  bool byte(uint8_t& out)
+  {
+    if (p >= end)
+      return false;
+    out = *p++;
+    return true;
+  }
+  bool bytes(uint64_t& out, int n)
+  {
+    out = 0;
+    for (int i = 0; i < n; ++i)
+    {
+      uint8_t b;
+      if (!byte(b))
+        return false;
+      out = (out << 8) | b;
+    }
+    return true;
+  }
+  bool skip(size_t n)
+  {
+    if (static_cast<size_t>(end - p) < n)
+      return false;
+    p += n;
+    return true;
+  }
+};
+
+bool readContainerCount(Reader& r,
+                        uint8_t first,
+                        uint8_t fix_mask,
+                        uint8_t fix_prefix,
+                        uint8_t tag16,
+                        uint8_t tag32,
+                        size_t& count)
+{
+  if ((first & 0xf0) == fix_prefix && fix_mask == 0xf0)
+  {
+    count = first & 0x0f;
+    return true;
+  }
+  uint64_t v;
+  if (first == tag16)
+  {
+    if (!r.bytes(v, 2))
+      return false;
+    count = static_cast<size_t>(v);
+    return true;
+  }
+  if (first == tag32)
+  {
+    if (!r.bytes(v, 4))
+      return false;
+    count = static_cast<size_t>(v);
+    return true;
+  }
+  return false;
+}
+
+// Reads one value, appending any numeric leaves to out. Strings/nil/bool are
+// consumed without contributing. Returns false on malformed input.
+bool readValueFloats(Reader& r, std::vector<float>& out)
+{
+  uint8_t b;
+  if (!r.byte(b))
+    return false;
+
+  if (b <= 0x7f)  // positive fixint
+  {
+    out.push_back(static_cast<float>(b));
+    return true;
+  }
+  if (b >= 0xe0)  // negative fixint
+  {
+    out.push_back(static_cast<float>(static_cast<int8_t>(b)));
+    return true;
+  }
+  if ((b & 0xe0) == 0xa0)  // fixstr
+    return r.skip(b & 0x1f);
+  if ((b & 0xf0) == 0x90)  // fixarray
+  {
+    const size_t n = b & 0x0f;
+    for (size_t i = 0; i < n; ++i)
+      if (!readValueFloats(r, out))
+        return false;
+    return true;
+  }
+  if ((b & 0xf0) == 0x80)  // fixmap
+  {
+    const size_t n = b & 0x0f;
+    for (size_t i = 0; i < 2 * n; ++i)
+      if (!readValueFloats(r, out))
+        return false;
+    return true;
+  }
+
+  uint64_t v;
+  switch (b)
+  {
+    case 0xc0:  // nil
+    case 0xc2:  // false
+    case 0xc3:  // true
+      return true;
+    case 0xcc:
+      return r.bytes(v, 1) && (out.push_back(static_cast<float>(v)), true);
+    case 0xcd:
+      return r.bytes(v, 2) && (out.push_back(static_cast<float>(v)), true);
+    case 0xce:
+      return r.bytes(v, 4) && (out.push_back(static_cast<float>(v)), true);
+    case 0xcf:
+      return r.bytes(v, 8) && (out.push_back(static_cast<float>(v)), true);
+    case 0xd0:
+      return r.bytes(v, 1) && (out.push_back(static_cast<float>(static_cast<int8_t>(v))), true);
+    case 0xd1:
+      return r.bytes(v, 2) && (out.push_back(static_cast<float>(static_cast<int16_t>(v))), true);
+    case 0xd2:
+      return r.bytes(v, 4) && (out.push_back(static_cast<float>(static_cast<int32_t>(v))), true);
+    case 0xd3:
+      return r.bytes(v, 8) && (out.push_back(static_cast<float>(static_cast<int64_t>(v))), true);
+    case 0xca:  // float32
+    {
+      if (!r.bytes(v, 4))
+        return false;
+      const uint32_t u = static_cast<uint32_t>(v);
+      float f;
+      std::memcpy(&f, &u, 4);
+      out.push_back(f);
+      return true;
+    }
+    case 0xcb:  // float64
+    {
+      if (!r.bytes(v, 8))
+        return false;
+      double d;
+      std::memcpy(&d, &v, 8);
+      out.push_back(static_cast<float>(d));
+      return true;
+    }
+    case 0xd9:  // str8
+      return r.bytes(v, 1) && r.skip(static_cast<size_t>(v));
+    case 0xda:  // str16
+      return r.bytes(v, 2) && r.skip(static_cast<size_t>(v));
+    case 0xdb:  // str32
+      return r.bytes(v, 4) && r.skip(static_cast<size_t>(v));
+    case 0xdc:  // array16
+    case 0xdd:  // array32
+    {
+      const int nbytes = (b == 0xdc) ? 2 : 4;
+      if (!r.bytes(v, nbytes))
+        return false;
+      for (uint64_t i = 0; i < v; ++i)
+        if (!readValueFloats(r, out))
+          return false;
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+
+bool readString(Reader& r, std::string& out)
+{
+  uint8_t b;
+  if (!r.byte(b))
+    return false;
+  size_t len;
+  if ((b & 0xe0) == 0xa0)
+  {
+    len = b & 0x1f;
+  }
+  else
+  {
+    uint64_t v;
+    if (b == 0xd9 && r.bytes(v, 1))
+      len = static_cast<size_t>(v);
+    else if (b == 0xda && r.bytes(v, 2))
+      len = static_cast<size_t>(v);
+    else
+      return false;
+  }
+  if (static_cast<size_t>(r.end - r.p) < len)
+    return false;
+  out.assign(reinterpret_cast<const char*>(r.p), len);
+  r.p += len;
+  return true;
+}
+}  // namespace
+
+std::vector<uint8_t> encodeActuators(const std::vector<float>& position,
+                                     const std::vector<float>& stiffness)
+{
+  std::vector<uint8_t> b;
+  writeByte(b, static_cast<uint8_t>(0x80 | 2));  // fixmap, 2 entries
+  writeFloatArray(b, "Position", position);
+  writeFloatArray(b, "Stiffness", stiffness);
+  return b;
+}
+
+bool decodeSensors(const uint8_t* data, size_t size, std::map<std::string, std::vector<float>>& out)
+{
+  Reader r{data, data + size};
+  uint8_t first;
+  if (!r.byte(first))
+    return false;
+  size_t count;
+  if (!readContainerCount(r, first, 0xf0, 0x80, 0xde, 0xdf, count))
+    return false;
+
+  for (size_t i = 0; i < count; ++i)
+  {
+    std::string key;
+    if (!readString(r, key))
+      return false;
+    std::vector<float> values;
+    if (!readValueFloats(r, values))
+      return false;
+    out[key] = std::move(values);
+  }
+  return true;
+}
+
+}  // namespace lola
+}  // namespace hardware
+}  // namespace naoqi

--- a/src/hardware/lola_system.cpp
+++ b/src/hardware/lola_system.cpp
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2025 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "naoqi_driver/hardware/lola_system.hpp"
+
+#include <algorithm>
+#include <cerrno>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <map>
+#include <unordered_map>
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "naoqi_driver/hardware/lola_protocol.hpp"
+#include "pluginlib/class_list_macros.hpp"
+#include "rclcpp/logging.hpp"
+
+namespace naoqi
+{
+namespace hardware
+{
+
+namespace
+{
+rclcpp::Logger logger()
+{
+  return rclcpp::get_logger("LolaSystem");
+}
+
+std::string getParam(const std::unordered_map<std::string, std::string>& params,
+                     const std::string& key,
+                     const std::string& fallback)
+{
+  const auto it = params.find(key);
+  return it != params.end() ? it->second : fallback;
+}
+}  // namespace
+
+LolaSystem::~LolaSystem()
+{
+  stopIo();
+}
+
+hardware_interface::CallbackReturn LolaSystem::on_init(const hardware_interface::HardwareInfo& info)
+{
+  if (SystemInterface::on_init(info) != hardware_interface::CallbackReturn::SUCCESS)
+    return hardware_interface::CallbackReturn::ERROR;
+
+  socket_path_ = getParam(info_.hardware_parameters, "lola_socket", "/tmp/robocup");
+  stiffness_ = std::stod(getParam(info_.hardware_parameters, "stiffness", "1.0"));
+
+  // Map each URDF joint to an index in LoLA's 25-joint order. RHipYawPitch is
+  // coupled to LHipYawPitch and shares its slot.
+  const auto& order = lola::jointOrder();
+  std::unordered_map<std::string, int> index_of;
+  for (size_t i = 0; i < order.size(); ++i)
+    index_of[order[i]] = static_cast<int>(i);
+
+  for (const auto& joint : info_.joints)
+  {
+    if (joint.command_interfaces.size() != 1 ||
+        joint.command_interfaces[0].name != hardware_interface::HW_IF_POSITION)
+    {
+      RCLCPP_ERROR(logger(),
+                   "Joint '%s' must expose exactly one 'position' command interface.",
+                   joint.name.c_str());
+      return hardware_interface::CallbackReturn::ERROR;
+    }
+    std::string name = joint.name == "RHipYawPitch" ? "LHipYawPitch" : joint.name;
+    const auto it = index_of.find(name);
+    if (it == index_of.end())
+    {
+      RCLCPP_ERROR(logger(), "Joint '%s' is not a LoLA joint.", joint.name.c_str());
+      return hardware_interface::CallbackReturn::ERROR;
+    }
+    joint_names_.push_back(joint.name);
+    lola_index_.push_back(it->second);
+  }
+
+  const size_t n = joint_names_.size();
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  positions_.assign(n, nan);
+  velocities_.assign(n, 0.0);
+  efforts_.assign(n, 0.0);
+  position_commands_.assign(n, nan);
+
+  const size_t lola_n = order.size();
+  sensor_position_.assign(lola_n, 0.0f);
+  command_position_.assign(lola_n, 0.0f);
+  command_stiffness_.assign(lola_n, 0.0f);  // limp until activated
+
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn
+LolaSystem::on_configure(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  fd_ = ::socket(AF_UNIX, SOCK_STREAM, 0);
+  if (fd_ < 0)
+  {
+    RCLCPP_ERROR(logger(), "Could not create LoLA socket: %s", std::strerror(errno));
+    return hardware_interface::CallbackReturn::ERROR;
+  }
+
+  sockaddr_un addr{};
+  addr.sun_family = AF_UNIX;
+  std::strncpy(addr.sun_path, socket_path_.c_str(), sizeof(addr.sun_path) - 1);
+  if (::connect(fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0)
+  {
+    RCLCPP_ERROR(logger(),
+                 "Could not connect to LoLA socket '%s': %s",
+                 socket_path_.c_str(),
+                 std::strerror(errno));
+    ::close(fd_);
+    fd_ = -1;
+    return hardware_interface::CallbackReturn::ERROR;
+  }
+
+  running_ = true;
+  io_ok_ = true;
+  io_thread_ = std::thread(&LolaSystem::ioLoop, this);
+
+  RCLCPP_INFO(logger(),
+              "Connected to LoLA at '%s' (%zu joints).",
+              socket_path_.c_str(),
+              joint_names_.size());
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn
+LolaSystem::on_cleanup(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  stopIo();
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+void LolaSystem::stopIo()
+{
+  running_ = false;
+  if (io_thread_.joinable())
+    io_thread_.join();
+  if (fd_ >= 0)
+  {
+    ::close(fd_);
+    fd_ = -1;
+  }
+}
+
+void LolaSystem::ioLoop()
+{
+  std::vector<uint8_t> buffer(4096);
+  while (running_)
+  {
+    const ssize_t received = ::recv(fd_, buffer.data(), buffer.size(), 0);
+    if (received <= 0)
+    {
+      io_ok_ = false;
+      break;
+    }
+
+    std::map<std::string, std::vector<float>> sensors;
+    if (lola::decodeSensors(buffer.data(), static_cast<size_t>(received), sensors))
+    {
+      const auto it = sensors.find("Position");
+      if (it != sensors.end() && it->second.size() == sensor_position_.size())
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        sensor_position_ = it->second;
+        sensor_received_ = true;
+      }
+    }
+
+    std::vector<float> position, stiffness;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      position = command_position_;
+      stiffness = command_stiffness_;
+    }
+    const std::vector<uint8_t> frame = lola::encodeActuators(position, stiffness);
+    if (::send(fd_, frame.data(), frame.size(), 0) < 0)
+    {
+      io_ok_ = false;
+      break;
+    }
+  }
+}
+
+std::vector<hardware_interface::StateInterface> LolaSystem::export_state_interfaces()
+{
+  std::vector<hardware_interface::StateInterface> interfaces;
+  for (size_t i = 0; i < joint_names_.size(); ++i)
+  {
+    interfaces.emplace_back(joint_names_[i], hardware_interface::HW_IF_POSITION, &positions_[i]);
+    interfaces.emplace_back(joint_names_[i], hardware_interface::HW_IF_VELOCITY, &velocities_[i]);
+    interfaces.emplace_back(joint_names_[i], hardware_interface::HW_IF_EFFORT, &efforts_[i]);
+  }
+  return interfaces;
+}
+
+std::vector<hardware_interface::CommandInterface> LolaSystem::export_command_interfaces()
+{
+  std::vector<hardware_interface::CommandInterface> interfaces;
+  for (size_t i = 0; i < joint_names_.size(); ++i)
+    interfaces.emplace_back(
+        joint_names_[i], hardware_interface::HW_IF_POSITION, &position_commands_[i]);
+  return interfaces;
+}
+
+hardware_interface::CallbackReturn
+LolaSystem::on_activate(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  // Seed commands from the latest sensed position so activation does not jump
+  // the robot, then raise stiffness so commands take effect.
+  std::lock_guard<std::mutex> lock(mutex_);
+  command_position_ = sensor_position_;
+  for (size_t i = 0; i < joint_names_.size(); ++i)
+    position_commands_[i] = sensor_position_[lola_index_[i]];
+  std::fill(command_stiffness_.begin(), command_stiffness_.end(), static_cast<float>(stiffness_));
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn
+LolaSystem::on_deactivate(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  std::fill(command_stiffness_.begin(), command_stiffness_.end(), 0.0f);
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::return_type LolaSystem::read(const rclcpp::Time& /*time*/,
+                                                 const rclcpp::Duration& /*period*/)
+{
+  if (!io_ok_)
+  {
+    RCLCPP_ERROR(logger(), "LoLA connection lost.");
+    return hardware_interface::return_type::ERROR;
+  }
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (size_t i = 0; i < joint_names_.size(); ++i)
+    positions_[i] = sensor_position_[lola_index_[i]];
+  return hardware_interface::return_type::OK;
+}
+
+hardware_interface::return_type LolaSystem::write(const rclcpp::Time& /*time*/,
+                                                  const rclcpp::Duration& /*period*/)
+{
+  if (!io_ok_)
+    return hardware_interface::return_type::ERROR;
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (size_t i = 0; i < joint_names_.size(); ++i)
+  {
+    if (!std::isnan(position_commands_[i]))
+      command_position_[lola_index_[i]] = static_cast<float>(position_commands_[i]);
+  }
+  return hardware_interface::return_type::OK;
+}
+
+}  // namespace hardware
+}  // namespace naoqi
+
+PLUGINLIB_EXPORT_CLASS(naoqi::hardware::LolaSystem, hardware_interface::SystemInterface)

--- a/src/hardware/session_factory.cpp
+++ b/src/hardware/session_factory.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2025 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "naoqi_driver/hardware/session_factory.hpp"
+
+#include <mutex>
+#include <stdexcept>
+
+#include <qi/application.hpp>
+
+#include "fake_naoqi/fake_naoqi.hpp"
+
+#if LIBQI_VERSION >= 29
+#include "driver_authenticator.hpp"
+#endif
+
+namespace naoqi
+{
+namespace hardware
+{
+
+namespace
+{
+/// libqi networking relies on a process-wide runtime that qi::Application sets
+/// up (event loops, logging). The naoqi_driver node owns a qi::ApplicationSession
+/// in main(); a hardware interface has no main(), so we create one qi::Application
+/// for the whole process the first time we connect to a real robot.
+///
+/// ASSUMPTION (untested against a real robot): creating qi::Application from
+/// within a pluginlib-loaded library, after the process already started, is
+/// sufficient to use qi::Session networking. Verify on hardware; if it is not,
+/// the controller_manager executable must create qi::Application in its main().
+void ensureQiRuntime()
+{
+  static std::once_flag flag;
+  std::call_once(flag, [] {
+    static int argc = 1;
+    static const char* arg0 = "naoqi_hardware";
+    static char* argv[] = {const_cast<char*>(arg0), nullptr};
+    static qi::Application app(argc, argv);
+  });
+}
+}  // namespace
+
+qi::SessionPtr makeSession(const ConnectionOptions& options)
+{
+  if (options.emulation)
+  {
+    return naoqi::fake::createFakeNaoqiSession(options.robot_type);
+  }
+
+  ensureQiRuntime();
+
+  std::string protocol = "tcp://";
+  int port = options.port;
+  const bool has_password = options.password != kNoPassword;
+
+#if LIBQI_VERSION >= 29
+  if (has_password)
+  {
+    protocol = "tcps://";
+    port = (port == 9559) ? 9503 : port;
+  }
+#endif
+
+  qi::SessionPtr session = qi::makeSession();
+
+#if LIBQI_VERSION >= 29
+  if (has_password)
+  {
+    auto* factory = new naoqi::DriverAuthenticatorFactory;
+    factory->user = options.user;
+    factory->pass = options.password;
+    session->setClientAuthenticatorFactory(qi::ClientAuthenticatorFactoryPtr(factory));
+  }
+#else
+  if (has_password)
+  {
+    throw std::runtime_error("A password was set but libqi < 2.9 does not support authentication.");
+  }
+#endif
+
+  const qi::Url url(protocol + options.ip + ":" + std::to_string(port));
+  qi::Future<void> connection = session->connect(url);
+  if (connection.hasError())
+  {
+    throw std::runtime_error("Failed to connect to NAOqi at " + url.str() + ": " +
+                             connection.error());
+  }
+
+  return session;
+}
+
+}  // namespace hardware
+}  // namespace naoqi

--- a/src/hardware/session_factory.cpp
+++ b/src/hardware/session_factory.cpp
@@ -48,9 +48,12 @@ void ensureQiRuntime()
 {
   static std::once_flag flag;
   std::call_once(flag, [] {
+    // qi::Application takes argc/argv by non-const reference, so both must be
+    // lvalues that outlive it (hence static).
     static int argc = 1;
-    static const char* arg0 = "naoqi_hardware";
-    static char* argv[] = {const_cast<char*>(arg0), nullptr};
+    static char arg0[] = "naoqi_hardware";
+    static char* argv_storage[] = {arg0, nullptr};
+    static char** argv = argv_storage;
     static qi::Application app(argc, argv);
   });
 }

--- a/src/naoqi_driver.cpp
+++ b/src/naoqi_driver.cpp
@@ -25,6 +25,8 @@
  */
 #include <tf2_ros/buffer.h>
 
+#include <rclcpp/create_timer.hpp>
+
 /*
  * PUBLIC INTERFACE
  */
@@ -235,7 +237,10 @@ void Driver::scheduleConverter(size_t conv_index)
                "Scheduling converter %s with period %ld ns",
                conv.name().c_str(),
                period.count());
-  auto timer = this->create_timer(period, [this, conv_index, one_shot]() {
+  // Free function rather than Node::create_timer (which does not exist on
+  // Humble) so the same ROS-clock timer works across Humble/Iron/Jazzy.
+  auto timer = rclcpp::create_timer(
+      this, this->get_clock(), rclcpp::Duration(period), [this, conv_index, one_shot]() {
     auto start_time = this->now();
     RCLCPP_DEBUG(this->get_logger(),
                  "Converter %s is being called (%ld ns)",

--- a/test/almotion_system_test.cpp
+++ b/test/almotion_system_test.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Drives the ALMotion ros2_control system through its full lifecycle against
+// the in-process fake NAOqi (no robot). Verifies that a position command flows
+// through write() -> ALMotion -> ALMemory -> read() back into the state
+// interfaces.
+
+#include <chrono>
+#include <cmath>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <rclcpp/rclcpp.hpp>
+
+#include "naoqi_driver/hardware/almotion_system.hpp"
+
+namespace
+{
+hardware_interface::HardwareInfo makeInfo(const std::vector<std::string>& joints)
+{
+  hardware_interface::HardwareInfo info;
+  info.name = "NaoSystem";
+  info.type = "system";
+  info.hardware_parameters["emulation_mode"] = "true";
+  info.hardware_parameters["robot_type"] = "nao";
+
+  for (const auto& name : joints)
+  {
+    hardware_interface::ComponentInfo joint;
+    joint.name = name;
+
+    hardware_interface::InterfaceInfo position_cmd;
+    position_cmd.name = "position";
+    joint.command_interfaces.push_back(position_cmd);
+
+    for (const std::string& state : {"position", "velocity", "effort"})
+    {
+      hardware_interface::InterfaceInfo s;
+      s.name = state;
+      joint.state_interfaces.push_back(s);
+    }
+    info.joints.push_back(joint);
+  }
+  return info;
+}
+}  // namespace
+
+TEST(naoqi_driver_hardware, almotion_position_round_trip)
+{
+  const std::vector<std::string> joints = {"HeadYaw", "HeadPitch"};
+  naoqi::hardware::AlMotionSystem system;
+
+  ASSERT_EQ(system.on_init(makeInfo(joints)), hardware_interface::CallbackReturn::SUCCESS);
+
+  const rclcpp_lifecycle::State state;
+  ASSERT_EQ(system.on_configure(state), hardware_interface::CallbackReturn::SUCCESS);
+
+  auto state_interfaces = system.export_state_interfaces();
+  auto command_interfaces = system.export_command_interfaces();
+  ASSERT_EQ(state_interfaces.size(), 3u * joints.size());
+  ASSERT_EQ(command_interfaces.size(), joints.size());
+
+  ASSERT_EQ(system.on_activate(state), hardware_interface::CallbackReturn::SUCCESS);
+
+  // Command HeadYaw to 0.5 rad through its position command interface.
+  bool commanded = false;
+  for (auto& cmd : command_interfaces)
+  {
+    if (cmd.get_name() == "HeadYaw/position")
+    {
+      (void)cmd.set_value(0.5);
+      commanded = true;
+    }
+  }
+  ASSERT_TRUE(commanded);
+
+  const rclcpp::Time time(0, 0, RCL_ROS_TIME);
+  const rclcpp::Duration period(0, 20000000);  // 20 ms
+  ASSERT_EQ(system.write(time, period), hardware_interface::return_type::OK);
+
+  // Read back until the fake robot reports the commanded angle.
+  double head_yaw = 0.0;
+  for (int i = 0; i < 200; ++i)
+  {
+    ASSERT_EQ(system.read(time, period), hardware_interface::return_type::OK);
+    for (auto& s : state_interfaces)
+    {
+      if (s.get_name() == "HeadYaw/position")
+        head_yaw = s.get_value();
+    }
+    if (std::abs(head_yaw - 0.5) < 1e-3)
+      break;
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  EXPECT_NEAR(head_yaw, 0.5, 1e-2);
+
+  EXPECT_EQ(system.on_deactivate(state), hardware_interface::CallbackReturn::SUCCESS);
+}
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+  testing::InitGoogleTest(&argc, argv);
+  const int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/test/dcm_system_test.cpp
+++ b/test/dcm_system_test.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2025 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Drives the DCM ros2_control system through its lifecycle against the fake
+// NAOqi (fake DCM + fake ALMemory). Verifies a position command flows through
+// write() -> DCM.setAlias -> ALMemory sensor key -> read().
+
+#include <cmath>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <rclcpp/rclcpp.hpp>
+
+#include "naoqi_driver/hardware/dcm_system.hpp"
+
+namespace
+{
+hardware_interface::HardwareInfo makeInfo(const std::vector<std::string>& joints)
+{
+  hardware_interface::HardwareInfo info;
+  info.name = "NaoDcmSystem";
+  info.type = "system";
+  info.hardware_parameters["emulation_mode"] = "true";
+  info.hardware_parameters["robot_type"] = "nao";
+
+  for (const auto& name : joints)
+  {
+    hardware_interface::ComponentInfo joint;
+    joint.name = name;
+
+    hardware_interface::InterfaceInfo position_cmd;
+    position_cmd.name = "position";
+    joint.command_interfaces.push_back(position_cmd);
+
+    for (const std::string& state : {"position", "velocity", "effort"})
+    {
+      hardware_interface::InterfaceInfo s;
+      s.name = state;
+      joint.state_interfaces.push_back(s);
+    }
+    info.joints.push_back(joint);
+  }
+  return info;
+}
+}  // namespace
+
+TEST(naoqi_driver_dcm, dcm_position_round_trip)
+{
+  const std::vector<std::string> joints = {"HeadYaw", "HeadPitch"};
+  naoqi::hardware::DcmSystem system;
+
+  ASSERT_EQ(system.on_init(makeInfo(joints)), hardware_interface::CallbackReturn::SUCCESS);
+
+  const rclcpp_lifecycle::State state;
+  ASSERT_EQ(system.on_configure(state), hardware_interface::CallbackReturn::SUCCESS);
+
+  auto state_interfaces = system.export_state_interfaces();
+  auto command_interfaces = system.export_command_interfaces();
+  ASSERT_EQ(state_interfaces.size(), 3u * joints.size());
+  ASSERT_EQ(command_interfaces.size(), joints.size());
+
+  ASSERT_EQ(system.on_activate(state), hardware_interface::CallbackReturn::SUCCESS);
+
+  bool commanded = false;
+  for (auto& cmd : command_interfaces)
+  {
+    if (cmd.get_name() == "HeadYaw/position")
+    {
+      (void)cmd.set_value(0.5);
+      commanded = true;
+    }
+  }
+  ASSERT_TRUE(commanded);
+
+  const rclcpp::Time time(0, 0, RCL_ROS_TIME);
+  const rclcpp::Duration period(0, 20000000);
+  ASSERT_EQ(system.write(time, period), hardware_interface::return_type::OK);
+
+  double head_yaw = 0.0;
+  ASSERT_EQ(system.read(time, period), hardware_interface::return_type::OK);
+  for (auto& s : state_interfaces)
+  {
+    if (s.get_name() == "HeadYaw/position")
+      head_yaw = s.get_value();
+  }
+  EXPECT_NEAR(head_yaw, 0.5, 1e-3);
+
+  EXPECT_EQ(system.on_deactivate(state), hardware_interface::CallbackReturn::SUCCESS);
+}
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+  testing::InitGoogleTest(&argc, argv);
+  const int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/test/fake_lola_server.hpp
+++ b/test/fake_lola_server.hpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2025 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef FAKE_LOLA_SERVER_HPP
+#define FAKE_LOLA_SERVER_HPP
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <map>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include "naoqi_driver/hardware/lola_protocol.hpp"
+
+namespace naoqi
+{
+namespace fake
+{
+
+/// Minimal LoLA server for tests: an AF_UNIX socket that, once a client
+/// connects, repeatedly sends a sensor frame and reads back an actuator frame,
+/// mirroring the commanded Position into the sensed Position so a commanded
+/// angle is read back. Uses the same MessagePack codec as the LoLA system.
+class FakeLolaServer
+{
+  public:
+  explicit FakeLolaServer(const std::string& path) : path_(path)
+  {
+    listen_fd_ = ::socket(AF_UNIX, SOCK_STREAM, 0);
+    ::unlink(path_.c_str());
+    sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    std::strncpy(addr.sun_path, path_.c_str(), sizeof(addr.sun_path) - 1);
+    ::bind(listen_fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+    ::listen(listen_fd_, 1);
+
+    mirror_position_.assign(hardware::lola::jointOrder().size(), 0.0f);
+    running_ = true;
+    thread_ = std::thread(&FakeLolaServer::serve, this);
+  }
+
+  ~FakeLolaServer()
+  {
+    running_ = false;
+    if (client_fd_ >= 0)
+      ::shutdown(client_fd_, SHUT_RDWR);
+    if (listen_fd_ >= 0)
+      ::shutdown(listen_fd_, SHUT_RDWR);
+    if (thread_.joinable())
+      thread_.join();
+    if (client_fd_ >= 0)
+      ::close(client_fd_);
+    if (listen_fd_ >= 0)
+      ::close(listen_fd_);
+    ::unlink(path_.c_str());
+  }
+
+  private:
+  void serve()
+  {
+    client_fd_ = ::accept(listen_fd_, nullptr, nullptr);
+    if (client_fd_ < 0)
+      return;
+
+    const std::vector<float> stiffness(mirror_position_.size(), 0.0f);
+    std::vector<uint8_t> buffer(4096);
+    while (running_)
+    {
+      const std::vector<uint8_t> frame =
+          hardware::lola::encodeActuators(mirror_position_, stiffness);
+      if (::send(client_fd_, frame.data(), frame.size(), 0) < 0)
+        break;
+
+      const ssize_t received = ::recv(client_fd_, buffer.data(), buffer.size(), 0);
+      if (received <= 0)
+        break;
+      std::map<std::string, std::vector<float>> actuators;
+      if (hardware::lola::decodeSensors(buffer.data(), static_cast<size_t>(received), actuators))
+      {
+        const auto it = actuators.find("Position");
+        if (it != actuators.end() && it->second.size() == mirror_position_.size())
+          mirror_position_ = it->second;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  }
+
+  std::string path_;
+  int listen_fd_ = -1;
+  int client_fd_ = -1;
+  std::thread thread_;
+  std::atomic<bool> running_{false};
+  std::vector<float> mirror_position_;
+};
+
+}  // namespace fake
+}  // namespace naoqi
+
+#endif  // FAKE_LOLA_SERVER_HPP

--- a/test/lola_system_test.cpp
+++ b/test/lola_system_test.cpp
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2025 Aldebaran
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Drives the LoLA ros2_control system against a fake LoLA Unix-socket server,
+// exercising the MessagePack codec, the IO thread and the URDF<->LoLA joint
+// mapping. Verifies a position command is read back through the socket.
+
+#include <chrono>
+#include <cmath>
+#include <map>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+#include <rclcpp/rclcpp.hpp>
+
+#include "fake_lola_server.hpp"
+#include "naoqi_driver/hardware/lola_protocol.hpp"
+#include "naoqi_driver/hardware/lola_system.hpp"
+
+namespace
+{
+hardware_interface::HardwareInfo makeInfo(const std::vector<std::string>& joints,
+                                          const std::string& socket_path)
+{
+  hardware_interface::HardwareInfo info;
+  info.name = "NaoLolaSystem";
+  info.type = "system";
+  info.hardware_parameters["lola_socket"] = socket_path;
+  info.hardware_parameters["stiffness"] = "1.0";
+
+  for (const auto& name : joints)
+  {
+    hardware_interface::ComponentInfo joint;
+    joint.name = name;
+    hardware_interface::InterfaceInfo position_cmd;
+    position_cmd.name = "position";
+    joint.command_interfaces.push_back(position_cmd);
+    for (const std::string& state : {"position", "velocity", "effort"})
+    {
+      hardware_interface::InterfaceInfo s;
+      s.name = state;
+      joint.state_interfaces.push_back(s);
+    }
+    info.joints.push_back(joint);
+  }
+  return info;
+}
+}  // namespace
+
+TEST(naoqi_driver_lola, lola_position_round_trip)
+{
+  const std::string socket_path = "/tmp/naoqi_lola_test_" + std::to_string(::getpid()) + ".sock";
+  naoqi::fake::FakeLolaServer server(socket_path);
+
+  const std::vector<std::string> joints = {"HeadYaw", "HeadPitch"};
+  naoqi::hardware::LolaSystem system;
+
+  ASSERT_EQ(system.on_init(makeInfo(joints, socket_path)),
+            hardware_interface::CallbackReturn::SUCCESS);
+
+  const rclcpp_lifecycle::State state;
+  ASSERT_EQ(system.on_configure(state), hardware_interface::CallbackReturn::SUCCESS);
+
+  auto state_interfaces = system.export_state_interfaces();
+  auto command_interfaces = system.export_command_interfaces();
+  ASSERT_EQ(state_interfaces.size(), 3u * joints.size());
+  ASSERT_EQ(command_interfaces.size(), joints.size());
+
+  // Let the IO thread exchange a few frames so the first sensor frame arrives.
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  ASSERT_EQ(system.on_activate(state), hardware_interface::CallbackReturn::SUCCESS);
+
+  bool commanded = false;
+  for (auto& cmd : command_interfaces)
+  {
+    if (cmd.get_name() == "HeadYaw/position")
+    {
+      (void)cmd.set_value(0.5);
+      commanded = true;
+    }
+  }
+  ASSERT_TRUE(commanded);
+
+  const rclcpp::Time time(0, 0, RCL_ROS_TIME);
+  const rclcpp::Duration period(0, 20000000);
+
+  double head_yaw = 0.0;
+  for (int i = 0; i < 200; ++i)
+  {
+    ASSERT_EQ(system.write(time, period), hardware_interface::return_type::OK);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    ASSERT_EQ(system.read(time, period), hardware_interface::return_type::OK);
+    for (auto& s : state_interfaces)
+    {
+      if (s.get_name() == "HeadYaw/position")
+        head_yaw = s.get_value();
+    }
+    if (std::abs(head_yaw - 0.5) < 1e-3)
+      break;
+  }
+  EXPECT_NEAR(head_yaw, 0.5, 1e-2);
+
+  EXPECT_EQ(system.on_deactivate(state), hardware_interface::CallbackReturn::SUCCESS);
+  EXPECT_EQ(system.on_cleanup(state), hardware_interface::CallbackReturn::SUCCESS);
+}
+
+TEST(naoqi_driver_lola, codec_round_trip)
+{
+  const size_t n = naoqi::hardware::lola::jointOrder().size();
+  std::vector<float> position(n), stiffness(n, 1.0f);
+  for (size_t i = 0; i < n; ++i)
+    position[i] = 0.01f * static_cast<float>(i);
+
+  const auto frame = naoqi::hardware::lola::encodeActuators(position, stiffness);
+  std::map<std::string, std::vector<float>> decoded;
+  ASSERT_TRUE(naoqi::hardware::lola::decodeSensors(frame.data(), frame.size(), decoded));
+  ASSERT_EQ(decoded["Position"].size(), n);
+  for (size_t i = 0; i < n; ++i)
+    EXPECT_NEAR(decoded["Position"][i], position[i], 1e-6);
+}
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+  testing::InitGoogleTest(&argc, argv);
+  const int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/test/real_robot_move.sh
+++ b/test/real_robot_move.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# Copyright 2025 Aldebaran
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+#
+# Human-in-the-loop test: command a small, safe head motion on a REAL robot
+# through the ros2_control stack, so a person can confirm the hardware
+# interface actually moves the robot.
+#
+# This is NOT run in CI (it needs a robot). Run it by hand:
+#
+#   ./test/real_robot_move.sh <robot_ip> [password] [plugin]
+#
+#   <robot_ip>   IP or hostname of the robot (required)
+#   [password]   NAOqi password (NAOqi >= 2.9). Omit for older robots.
+#   [plugin]     Hardware plugin. Default: naoqi_driver/AlMotionSystem
+#                Others (when implemented): naoqi_driver/DcmSystem,
+#                naoqi_driver/LolaSystem
+#
+# Prerequisites: the workspace is built and sourced; the robot is reachable;
+# there is room around the robot. The script nods the head ~0.3 rad and back.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <robot_ip> [password] [plugin]" >&2
+  exit 2
+fi
+
+ROBOT_IP="$1"
+PASSWORD="${2:-no_password}"
+PLUGIN="${3:-naoqi_driver/AlMotionSystem}"
+CONTROLLER="nao_joint_trajectory_controller"
+
+echo "============================================================"
+echo " REAL ROBOT MOTION TEST"
+echo "   robot:   ${ROBOT_IP}"
+echo "   plugin:  ${PLUGIN}"
+echo "   motion:  HeadYaw -> +0.3 rad -> 0.0 rad"
+echo "============================================================"
+echo "Make sure the robot is awake and has room to move its head."
+echo "Tip: 'ssh nao@${ROBOT_IP}' then"
+echo "     'qicli call ALAutonomousLife.setState disabled' and"
+echo "     'qicli call ALMotion.wakeUp' before running this."
+read -r -p "Press Enter to start, Ctrl-C to abort... " _
+
+# Bring up controller_manager + controllers against the real robot.
+ros2 launch naoqi_driver ros2_control.launch.py \
+  emulation_mode:=false \
+  plugin:="${PLUGIN}" \
+  nao_ip:="${ROBOT_IP}" \
+  password:="${PASSWORD}" &
+LAUNCH_PID=$!
+trap 'kill "${LAUNCH_PID}" 2>/dev/null || true' EXIT
+
+echo "Waiting for ${CONTROLLER} to become active..."
+for _ in $(seq 1 30); do
+  if ros2 control list_controllers 2>/dev/null | grep -q "${CONTROLLER}.*active"; then
+    break
+  fi
+  sleep 1
+done
+ros2 control list_controllers || true
+
+echo "Sending head motion goal..."
+ros2 action send_goal "/${CONTROLLER}/follow_joint_trajectory" \
+  control_msgs/action/FollowJointTrajectory "{
+  trajectory: {
+    joint_names: [HeadYaw],
+    points: [
+      { positions: [0.3], time_from_start: { sec: 2 } },
+      { positions: [0.0], time_from_start: { sec: 4 } }
+    ]
+  }
+}"
+
+echo "Goal finished. Did the head move? (human verification)"
+echo "Shutting down..."

--- a/test/real_robot_move.sh
+++ b/test/real_robot_move.sh
@@ -24,18 +24,20 @@
 set -euo pipefail
 
 if [[ $# -lt 1 ]]; then
-  echo "usage: $0 <robot_ip> [password] [plugin]" >&2
+  echo "usage: $0 <robot_ip> [password] [plugin] [robot]" >&2
+  echo "  [robot] is 'nao' (default) or 'pepper'" >&2
   exit 2
 fi
 
 ROBOT_IP="$1"
 PASSWORD="${2:-no_password}"
 PLUGIN="${3:-naoqi_driver/AlMotionSystem}"
-CONTROLLER="nao_joint_trajectory_controller"
+ROBOT="${4:-nao}"
+CONTROLLER="${ROBOT}_joint_trajectory_controller"
 
 echo "============================================================"
 echo " REAL ROBOT MOTION TEST"
-echo "   robot:   ${ROBOT_IP}"
+echo "   robot:   ${ROBOT} @ ${ROBOT_IP}"
 echo "   plugin:  ${PLUGIN}"
 echo "   motion:  HeadYaw -> +0.3 rad -> 0.0 rad"
 echo "============================================================"
@@ -47,6 +49,7 @@ read -r -p "Press Enter to start, Ctrl-C to abort... " _
 
 # Bring up controller_manager + controllers against the real robot.
 ros2 launch naoqi_driver ros2_control.launch.py \
+  robot:="${ROBOT}" \
   emulation_mode:=false \
   plugin:="${PLUGIN}" \
   nao_ip:="${ROBOT_IP}" \


### PR DESCRIPTION
## What

First vertical slice of `ros2_control` for NAO/Pepper, on top of the `fake_naoqi` emulation study (this PR targets `fake_naoqi`, not `main`, so the diff is just the new work).

Three transports to the robot map to three `SystemInterface` plugins, selected from the URDF — no internal backend switching. This PR implements the **ALMotion** one; DCM and LoLA are planned (see `CURRENT_PLAN.md`).

| Plugin | Transport | Targets | Command |
|---|---|---|---|
| `naoqi_driver/AlMotionSystem` ✅ | libqi → ALMotion | NAOqi 2.1–2.9 (universal) | position |
| `naoqi_driver/DcmSystem` (planned) | libqi → DCM + ALMemory | NAO 2.1 / Pepper 2.5 | position (+velocity, key TBD) |
| `naoqi_driver/LolaSystem` (planned) | `/tmp/robocup` socket | NAO 2.8+ / Pepper 2.9 | position |

## Implemented

- **`AlMotionSystem`** (`src/hardware/almotion_system.*`): position command via `ALMotion.setAngles`; position/velocity/effort state read from ALMemory in one batched `getListData` (same keys as the `joint_state` converter). Velocity is state-only — ALMotion has no native velocity command.
- **`session_factory`** (`src/hardware/session_factory.*`): builds a libqi session — real robot or in-process fake — from ros2_control params. Shared with the future DCM backend.
- Pluginlib export, a reusable `naoqi_system` xacro macro + self-contained `nao.urdf.xacro`, `nao_controllers.yaml`, `ros2_control.launch.py`, CMake/package.xml wiring.
- **Tests**: `test/almotion_system_test.cpp` drives the full lifecycle against the fake NAOqi in CI (no robot); `test/real_robot_move.sh <ip> [password]` nods a real robot's head for human verification.
- Docs: `CURRENT_PLAN.md` (roadmap + backend matrix) and `ASSUMPTIONS.md` (every unverified fact to test on hardware, incl. confirmed DCM/LoLA keys and the open per-joint DCM velocity-key question).

## Incidental fix

`naoqi_driver.cpp` used `Node::create_timer`, which doesn't exist on Humble; switched to the `rclcpp::create_timer` free function (same ROS-clock semantics, builds on Humble/Iron/Jazzy).

## CI status

- **Humble: green**, **Iron: green** — the slice compiles and the emulation test passes on both.
- **Jazzy: red** — `naoqi_libqicore` isn't released for Jazzy upstream (rosdep can't resolve it); not a code issue, left as-is until the dependency is available.

## Notable assumptions to verify on hardware (see `ASSUMPTIONS.md`)

- Per-joint **DCM velocity key** is not confirmed in any open source (only Pepper wheels' `RotationVelocity/Actuator/Value` is). Candidates listed for probing.
- LoLA on Pepper 2.9 (hidden API) — socket path and joint order unknown.
- libqi runtime created from inside `controller_manager` (lazy `qi::Application`) is untested against a real robot.

https://claude.ai/code/session_01THHKwpqfVfwZrnmD4tF1Be

---
_Generated by [Claude Code](https://claude.ai/code/session_01THHKwpqfVfwZrnmD4tF1Be)_